### PR TITLE
feat: setup Dexie database and sync placeholder

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"No tests defined\""
+  },
+  "dependencies": {
+    "dexie": "^3.2.4"
+  }
+}

--- a/web/src/db.ts
+++ b/web/src/db.ts
@@ -1,0 +1,42 @@
+import Dexie, { Table } from 'dexie';
+
+export interface CatalogItem {
+  id: string;
+  data: unknown;
+}
+
+export interface Client {
+  id: string;
+  name: string;
+}
+
+export interface CartDraft {
+  id: string;
+  items: unknown[];
+}
+
+export interface PendingMutation {
+  id?: number; // Auto-incremented primary key
+  timestamp: number;
+  operation: string;
+  payload: unknown;
+}
+
+class LollyspaceDB extends Dexie {
+  catalog!: Table<CatalogItem, string>;
+  recentClients!: Table<Client, string>;
+  cartDrafts!: Table<CartDraft, string>;
+  pendingMutations!: Table<PendingMutation, number>;
+
+  constructor() {
+    super('lollyspace');
+    this.version(1).stores({
+      catalog: 'id',
+      recentClients: 'id',
+      cartDrafts: 'id',
+      pendingMutations: '++id,timestamp'
+    });
+  }
+}
+
+export const db = new LollyspaceDB();

--- a/web/src/sync.ts
+++ b/web/src/sync.ts
@@ -1,0 +1,28 @@
+import { db, PendingMutation } from './db';
+
+/**
+ * Queue a mutation for later synchronization.
+ */
+export async function queueMutation(mutation: Omit<PendingMutation, 'id'>) {
+  await db.pendingMutations.add(mutation);
+}
+
+/**
+ * Replay pending mutations in FIFO order.
+ * Placeholder implementation that simply logs each mutation before
+ * removing it from the queue.
+ */
+export async function syncPendingMutations() {
+  const mutations = await db.pendingMutations.orderBy('id').toArray();
+  for (const mutation of mutations) {
+    await sendToServer(mutation);
+    if (mutation.id !== undefined) {
+      await db.pendingMutations.delete(mutation.id);
+    }
+  }
+}
+
+async function sendToServer(mutation: PendingMutation) {
+  // TODO: Replace with real server communication logic
+  console.debug('Syncing mutation', mutation);
+}


### PR DESCRIPTION
## Summary
- initialize Dexie database for catalog, clients, cart drafts, and pending mutations
- add placeholder sync logic with FIFO mutation replay

## Testing
- `npm test --prefix web`


------
https://chatgpt.com/codex/tasks/task_e_6897bb45ff2c832bb82f9af4d0a60250