### PR TITLE
feat: scaffold web client with Vite and Tailwind

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/web/components.json
+++ b/web/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lollyspace Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0",
+    "recharts": "^2.8.0",
+    "zustand": "^4.4.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^1.14.0",
+    "tailwindcss-animate": "^1.0.7"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.30",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,17 @@
+import { Link, Outlet } from 'react-router-dom';
+
+export default function App() {
+  return (
+    <div className="min-h-screen">
+      <nav className="bg-primary text-white p-4 flex gap-4">
+        <Link to="/">Home</Link>
+        <Link to="/client">Client</Link>
+        <Link to="/advisor">Advisor</Link>
+        <Link to="/admin">Admin</Link>
+      </nav>
+      <main className="p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/web/src/components/ProductCard.tsx
+++ b/web/src/components/ProductCard.tsx
@@ -1,0 +1,15 @@
+interface ProductCardProps {
+  title: string;
+  description: string;
+  price: string;
+}
+
+export function ProductCard({ title, description, price }: ProductCardProps) {
+  return (
+    <div className="border rounded p-4 shadow">
+      <h3 className="text-lg font-heading">{title}</h3>
+      <p className="text-sm text-gray-600">{description}</p>
+      <div className="mt-2 font-bold">{price}</div>
+    </div>
+  );
+}

--- a/web/src/components/SearchBarDual.tsx
+++ b/web/src/components/SearchBarDual.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+interface SearchBarDualProps {
+  onSearch?: (primary: string, secondary: string) => void;
+}
+
+export function SearchBarDual({ onSearch }: SearchBarDualProps) {
+  const [primary, setPrimary] = useState('');
+  const [secondary, setSecondary] = useState('');
+
+  return (
+    <div className="flex gap-2">
+      <input
+        value={primary}
+        onChange={(e) => setPrimary(e.target.value)}
+        placeholder="Search..."
+        className="border p-2 flex-1"
+      />
+      <input
+        value={secondary}
+        onChange={(e) => setSecondary(e.target.value)}
+        placeholder="Filter..."
+        className="border p-2 flex-1"
+      />
+      <button
+        onClick={() => onSearch?.(primary, secondary)}
+        className="bg-primary text-white px-4 py-2"
+      >
+        Go
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/VolumeButtons.tsx
+++ b/web/src/components/VolumeButtons.tsx
@@ -1,0 +1,13 @@
+import { useVolumeStore } from '@/store/volume';
+
+export function VolumeButtons() {
+  const { volume, increase, decrease } = useVolumeStore();
+
+  return (
+    <div className="flex items-center gap-2">
+      <button onClick={decrease} className="px-2 py-1 border rounded">-</button>
+      <span>{volume}</span>
+      <button onClick={increase} className="px-2 py-1 border rounded">+</button>
+    </div>
+  );
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,14 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading;
+  }
+  body {
+    @apply font-sans;
+  }
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import Home from './pages/Home';
+import Client from './pages/Client';
+import Advisor from './pages/Advisor';
+import Admin from './pages/Admin';
+import './index.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />}>
+            <Route index element={<Home />} />
+            <Route path="client" element={<Client />} />
+            <Route path="advisor" element={<Advisor />} />
+            <Route path="admin" element={<Admin />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -1,0 +1,3 @@
+export default function Admin() {
+  return <div className="text-2xl">Admin Page</div>;
+}

--- a/web/src/pages/Advisor.tsx
+++ b/web/src/pages/Advisor.tsx
@@ -1,0 +1,3 @@
+export default function Advisor() {
+  return <div className="text-2xl">Advisor Page</div>;
+}

--- a/web/src/pages/Client.tsx
+++ b/web/src/pages/Client.tsx
@@ -1,0 +1,14 @@
+import { ProductCard } from '@/components/ProductCard';
+import { SearchBarDual } from '@/components/SearchBarDual';
+import { VolumeButtons } from '@/components/VolumeButtons';
+
+export default function Client() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl">Client Page</h2>
+      <SearchBarDual />
+      <ProductCard title="Sample Product" description="Demo item" price="$19.99" />
+      <VolumeButtons />
+    </div>
+  );
+}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,0 +1,22 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+
+const data = [
+  { name: 'Jan', value: 30 },
+  { name: 'Feb', value: 50 },
+  { name: 'Mar', value: 40 },
+];
+
+export default function Home() {
+  return (
+    <div>
+      <h2 className="text-2xl mb-4">Home Page</h2>
+      <LineChart width={300} height={100} data={data}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Line type="monotone" dataKey="value" stroke="#8884d8" />
+      </LineChart>
+    </div>
+  );
+}

--- a/web/src/store/volume.ts
+++ b/web/src/store/volume.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface VolumeState {
+  volume: number;
+  increase: () => void;
+  decrease: () => void;
+}
+
+export const useVolumeStore = create<VolumeState>((set) => ({
+  volume: 50,
+  increase: () => set((s) => ({ volume: s.volume + 10 })),
+  decrease: () => set((s) => ({ volume: s.volume - 10 })),
+}));

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'tailwindcss';
+import animate from 'tailwindcss-animate';
+import { fontFamily } from 'tailwindcss/defaultTheme';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#1e3a8a',
+        secondary: '#9333ea',
+      },
+      fontFamily: {
+        heading: ['"Playfair Display"', ...fontFamily.serif],
+        sans: ['Montserrat', ...fontFamily.sans],
+      },
+    },
+  },
+  plugins: [animate],
+};
+
+export default config;

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- initialize Vite + React + TS app with Tailwind and shadcn config
- add React Router, React Query, Zustand, Recharts deps and basic pages
- provide ProductCard, SearchBarDual, and VolumeButtons components

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find type definition file for 'node', 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6897bb3ef1d0832b8ef454dca82f76d0