### PR TITLE
feat: add product search RPC and frontend support

### DIFF
--- a/supabase/migrations/20250809010000_search_products.sql
+++ b/supabase/migrations/20250809010000_search_products.sql
@@ -1,0 +1,37 @@
+-- RPC for searching products with combined fields and pagination
+create or replace function public.search_products(
+  query text default '',
+  page int default 1,
+  per_page int default 20
+)
+returns setof public.products
+language sql
+stable
+as $$
+  select *
+  from public.products
+  where (
+      query = '' or
+      to_tsvector('simple',
+        coalesce(inspired_name,'') || ' ' ||
+        coalesce(inspired_brand,'') || ' ' ||
+        coalesce(array_to_string(top_notes,' '), '') || ' ' ||
+        coalesce(array_to_string(heart_notes,' '), '') || ' ' ||
+        coalesce(array_to_string(base_notes,' '), '')
+      ) @@ plainto_tsquery('simple', query)
+    )
+    and active
+  order by id
+  limit per_page offset (page - 1) * per_page;
+$$;
+
+-- Combined GIN index for search
+create index if not exists products_search_idx on public.products using gin (
+  to_tsvector('simple',
+    coalesce(inspired_name,'') || ' ' ||
+    coalesce(inspired_brand,'') || ' ' ||
+    coalesce(array_to_string(top_notes,' '), '') || ' ' ||
+    coalesce(array_to_string(heart_notes,' '), '') || ' ' ||
+    coalesce(array_to_string(base_notes,' '), '')
+  )
+);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/web/src/pages/Client.tsx
+++ b/web/src/pages/Client.tsx
@@ -1,13 +1,44 @@
+import { useState } from 'react';
 import ProductCard from '../components/ProductCard';
 import SearchBarDual from '../components/SearchBarDual';
+import { useSearchProducts } from '../services/products';
+import { useCartStore } from '../stores/cart';
 
 export default function Client() {
+  const [term, setTerm] = useState('');
+  const [page, setPage] = useState(1);
+  const { data } = useSearchProducts(term, page);
+  const add = useCartStore((s) => s.add);
+
   return (
     <div className="space-y-4">
-      <SearchBarDual onSearch={() => {}} />
+      <SearchBarDual
+        onSearch={(value) => {
+          setTerm(value);
+          setPage(1);
+        }}
+      />
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <ProductCard name="Sample" brand="Brand" onAdd={() => {}} />
+        {data?.map((p) => (
+          <ProductCard
+            key={p.id}
+            name={p.inspired_name}
+            brand={p.inspired_brand}
+            onAdd={() => add({ id: p.id, name: p.inspired_name })}
+          />
+        ))}
       </div>
+      {term && (
+        <div className="flex items-center gap-2">
+          <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+            Prev
+          </button>
+          <span>{page}</span>
+          <button onClick={() => setPage((p) => p + 1)} disabled={!data || data.length < 20}>
+            Next
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/services/products.ts
+++ b/web/src/services/products.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface Product {
+  id: number;
+  inspired_name: string;
+  inspired_brand: string;
+}
+
+async function searchProducts(query: string, page: number) {
+  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/rpc/search_products`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ query, page, per_page: 20 }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as Product[];
+}
+
+export function useSearchProducts(query: string, page: number) {
+  return useQuery({
+    queryKey: ['products', query, page],
+    queryFn: () => searchProducts(query, page),
+    enabled: query.length > 0,
+  });
+}

--- a/web/src/stores/cart.ts
+++ b/web/src/stores/cart.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+export interface CartItem {
+  id: number;
+  name: string;
+  quantity: number;
+}
+
+interface CartState {
+  items: CartItem[];
+  add: (item: { id: number; name: string }) => void;
+}
+
+export const useCartStore = create<CartState>((set) => ({
+  items: [],
+  add: (item) =>
+    set((state) => {
+      const existing = state.items.find((i) => i.id === item.id);
+      if (existing) {
+        return {
+          items: state.items.map((i) =>
+            i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+          ),
+        };
+      }
+      return { items: [...state.items, { ...item, quantity: 1 }] };
+    }),
+}));

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add RPC `search_products` with GIN index for combined product search
- create React Query service and integrate search with pagination in client page
- introduce Zustand cart store and enable adding items from search results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `supabase --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c6530590832b83106f97e1a0b245