### PR TITLE
feat: add admin product & promotion management with analytics export

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,8 @@ import Home from './pages/Home';
 import Client from './pages/Client';
 import Advisor from './pages/Advisor';
 import Admin from './pages/Admin';
+import AdminProducts from './pages/AdminProducts';
+import AdminPromotions from './pages/AdminPromotions';
 
 export default function App() {
   return (
@@ -18,9 +20,11 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/client" element={<Client />} />
           <Route path="/advisor" element={<Advisor />} />
-          <Route path="/admin" element={<Admin />} />
-        </Routes>
-      </main>
-    </div>
-  );
-}
+            <Route path="/admin" element={<Admin />} />
+            <Route path="/admin/products" element={<AdminProducts />} />
+            <Route path="/admin/promotions" element={<AdminPromotions />} />
+          </Routes>
+        </main>
+      </div>
+    );
+  }

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -1,7 +1,95 @@
+import { Link } from 'react-router-dom';
+import { useOrders } from '../services/admin';
+import { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts';
+
 export default function Admin() {
+  const { data: orders } = useOrders();
+
+  const chartData = useMemo(() => {
+    if (!orders) return [] as { date: string; revenue: number; sales: number }[];
+    const map = new Map<string, { date: string; revenue: number; sales: number }>();
+    for (const o of orders) {
+      const date = o.created_at.slice(0, 10);
+      const item = map.get(date) || { date, revenue: 0, sales: 0 };
+      item.revenue += Number(o.total_tnd);
+      item.sales += 1;
+      map.set(date, item);
+    }
+    return Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+  }, [orders]);
+
+  async function exportXlsx() {
+    const res = await fetch(
+      `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/export_sales_xlsx`,
+      {
+        headers: {
+          apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+          Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        },
+      },
+    );
+    if (!res.ok) {
+      alert('Export failed');
+      return;
+    }
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'sales.xlsx';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  }
+
   return (
     <div>
       <h1 className="font-serif text-2xl">Admin Area</h1>
+      <nav className="mt-4 flex gap-4">
+        <Link to="/admin/products">Produits</Link>
+        <Link to="/admin/promotions">Promotions</Link>
+      </nav>
+      <div className="mt-8 grid gap-8 md:grid-cols-2">
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="revenue" stroke="#8884d8" />
+            </LineChart>
+          </ResponsiveContainer>
+          <p className="text-center mt-2">Chiffre d'affaires</p>
+        </div>
+        <div className="w-full h-64">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="sales" stroke="#82ca9d" />
+            </LineChart>
+          </ResponsiveContainer>
+          <p className="text-center mt-2">Nombre de ventes</p>
+        </div>
+      </div>
+      <button
+        onClick={exportXlsx}
+        className="mt-8 px-4 py-2 bg-primary text-background"
+      >
+        Export .xlsx
+      </button>
     </div>
   );
 }
+

--- a/web/src/pages/AdminProducts.tsx
+++ b/web/src/pages/AdminProducts.tsx
@@ -1,0 +1,38 @@
+import { useAllProducts, updateProductStatus, Product } from '../services/products';
+
+export default function AdminProducts() {
+  const { data: products, refetch } = useAllProducts();
+
+  async function toggle(product: Product) {
+    await updateProductStatus(product.id, !product.active);
+    refetch();
+  }
+
+  const active = products?.filter(p => p.active) ?? [];
+  const inactive = products?.filter(p => !p.active) ?? [];
+
+  return (
+    <div>
+      <h1 className="font-serif text-2xl">Gestion des produits</h1>
+      <h2 className="mt-4 font-semibold">Actifs</h2>
+      <ul className="mt-2 flex flex-col gap-1">
+        {active.map(p => (
+          <li key={p.id} className="flex justify-between">
+            <span>{p.inspired_name}</span>
+            <button onClick={() => toggle(p)} className="text-sm text-red-500">Mettre en veille</button>
+          </li>
+        ))}
+      </ul>
+      <h2 className="mt-6 font-semibold">En veille</h2>
+      <ul className="mt-2 flex flex-col gap-1">
+        {inactive.map(p => (
+          <li key={p.id} className="flex justify-between">
+            <span>{p.inspired_name}</span>
+            <button onClick={() => toggle(p)} className="text-sm text-green-600">Activer</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/web/src/pages/AdminPromotions.tsx
+++ b/web/src/pages/AdminPromotions.tsx
@@ -1,0 +1,27 @@
+import { usePromotions, updatePromotion, Promotion } from '../services/promotions';
+
+export default function AdminPromotions() {
+  const { data: promotions, refetch } = usePromotions();
+
+  async function toggle(promo: Promotion) {
+    await updatePromotion(promo.id, !promo.active);
+    refetch();
+  }
+
+  return (
+    <div>
+      <h1 className="font-serif text-2xl">Gestion des promotions</h1>
+      <ul className="mt-4 flex flex-col gap-1">
+        {promotions?.map(p => (
+          <li key={p.id} className="flex justify-between">
+            <span>{p.type}</span>
+            <button onClick={() => toggle(p)} className="text-sm text-primary">
+              {p.active ? 'Désactiver' : 'Activer'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/web/src/services/admin.ts
+++ b/web/src/services/admin.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface Order {
+  id: number;
+  order_code: string;
+  total_tnd: number;
+  created_at: string;
+}
+
+export interface OrderItem {
+  id: number;
+  order_id: number;
+  product_variant_id: number;
+  quantity: number;
+  unit_price_tnd: number;
+  discount_tnd: number;
+}
+
+export interface AdminSetting {
+  key: string;
+  value: unknown;
+  updated_at: string;
+}
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const headers = {
+  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+};
+
+async function fetchWithRls(path: string) {
+  const res = await fetch(`${baseUrl}/rest/v1/${path}`, { headers });
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('RLS: access denied');
+  }
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}
+
+export function useOrders() {
+  return useQuery({
+    queryKey: ['orders'],
+    queryFn: () => fetchWithRls('orders?select=*'),
+  });
+}
+
+export function useOrderItems(orderId: number) {
+  return useQuery({
+    queryKey: ['order_items', orderId],
+    queryFn: () => fetchWithRls(`order_items?order_id=eq.${orderId}&select=*`),
+    enabled: !!orderId,
+  });
+}
+
+export function useAdminSettings() {
+  return useQuery({
+    queryKey: ['admin_settings'],
+    queryFn: () => fetchWithRls('admin_settings?select=*'),
+  });
+}
+

--- a/web/src/services/products.ts
+++ b/web/src/services/products.ts
@@ -4,6 +4,7 @@ export interface Product {
   id: number;
   inspired_name: string;
   inspired_brand: string;
+  active: boolean;
 }
 
 async function searchProducts(query: string, page: number) {
@@ -29,4 +30,38 @@ export function useSearchProducts(query: string, page: number) {
     queryFn: () => searchProducts(query, page),
     enabled: query.length > 0,
   });
+}
+
+async function fetchProducts() {
+  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/products?select=*`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as Product[];
+}
+
+export function useAllProducts() {
+  return useQuery({ queryKey: ['all-products'], queryFn: fetchProducts });
+}
+
+export async function updateProductStatus(id: number, active: boolean) {
+  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/products?id=eq.${id}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ active }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
 }

--- a/web/src/services/promotions.ts
+++ b/web/src/services/promotions.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface Promotion {
+  id: number;
+  type: string;
+  starts_at: string;
+  ends_at: string;
+  active: boolean;
+}
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const headers = {
+  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+  'Content-Type': 'application/json',
+};
+
+async function fetchPromotions() {
+  const res = await fetch(`${baseUrl}/rest/v1/promotions?select=*`, { headers });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as Promotion[];
+}
+
+export function usePromotions() {
+  return useQuery({ queryKey: ['promotions'], queryFn: fetchPromotions });
+}
+
+export async function updatePromotion(id: number, active: boolean) {
+  const res = await fetch(`${baseUrl}/rest/v1/promotions?id=eq.${id}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({ active }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add admin routes for product and promotion management
- display sales KPIs with Recharts and support XLSX export
- expose services for orders, order items and admin settings with RLS checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897c7d3f0ac832ba4c156674e3eb5ea