### PR TITLE
feat: advisor tabs and checkout edge function

### DIFF
--- a/edge-functions/checkout_advisor/index.ts
+++ b/edge-functions/checkout_advisor/index.ts
@@ -1,0 +1,79 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
+import postgres from "https://deno.land/x/postgresjs@v3.3.3/mod.js";
+
+const sql = postgres(Deno.env.get("DATABASE_URL")!, { ssl: "require" });
+
+const itemSchema = z.object({
+  product_variant_id: z.number().int(),
+  quantity: z.number().int().positive(),
+  unit_price_tnd: z.number().nonnegative(),
+  discount_tnd: z.number().nonnegative().optional().default(0),
+});
+
+const bodySchema = z.object({
+  advisor_id: z.string().uuid(),
+  client: z.union([
+    z.object({ id: z.string().uuid() }),
+    z.object({
+      first_name: z.string(),
+      last_name: z.string(),
+      phone: z.string(),
+    }),
+  ]),
+  items: z.array(itemSchema).min(1),
+});
+
+serve(async (req) => {
+  try {
+    const payload = await req.json();
+    const data = bodySchema.parse(payload);
+
+    const total = data.items.reduce(
+      (sum, i) => sum + (i.unit_price_tnd - (i.discount_tnd ?? 0)) * i.quantity,
+      0
+    );
+    const code = crypto.randomUUID();
+
+    const result = await sql.begin(async (tx) => {
+      let clientId: string;
+      if ("id" in data.client) {
+        clientId = data.client.id;
+      } else {
+        const inserted = await tx`
+          insert into profiles (role, first_name, last_name, phone)
+          values ('client', ${data.client.first_name}, ${data.client.last_name}, ${data.client.phone})
+          returning id
+        `;
+        clientId = inserted[0].id;
+      }
+
+      const order = await tx`
+        insert into orders (order_code, user_id, advisor_id, total_tnd)
+        values (${code}, ${clientId}, ${data.advisor_id}, ${total})
+        returning id
+      `;
+      const orderId = order[0].id;
+
+      for (const item of data.items) {
+        await tx`
+          insert into order_items (order_id, product_variant_id, quantity, unit_price_tnd, discount_tnd)
+          values (${orderId}, ${item.product_variant_id}, ${item.quantity}, ${item.unit_price_tnd}, ${item.discount_tnd ?? 0})
+        `;
+      }
+
+      return { order_id: orderId, order_code: code, client_id: clientId };
+    });
+
+    return new Response(JSON.stringify(result), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (err) {
+    const message = err instanceof z.ZodError ? err.errors : err.message;
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,10 +19,10 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/client" element={<Client />} />
-          <Route path="/advisor" element={<Advisor />} />
-            <Route path="/admin" element={<Admin />} />
-            <Route path="/admin/products" element={<AdminProducts />} />
-            <Route path="/admin/promotions" element={<AdminPromotions />} />
+          <Route path="/advisor/*" element={<Advisor />} />
+          <Route path="/admin" element={<Admin />} />
+          <Route path="/admin/products" element={<AdminProducts />} />
+          <Route path="/admin/promotions" element={<AdminPromotions />} />
           </Routes>
         </main>
       </div>

--- a/web/src/pages/Advisor.tsx
+++ b/web/src/pages/Advisor.tsx
@@ -1,7 +1,42 @@
+import { NavLink, Routes, Route } from 'react-router-dom';
+import AdvisorCatalog from './AdvisorCatalog';
+import AdvisorFavorites from './AdvisorFavorites';
+import AdvisorDashboard from './AdvisorDashboard';
+import AdvisorHistory from './AdvisorHistory';
+import { useCartStore } from '../stores/cart';
+import { clearLocalDb } from '../services/localDb';
+
 export default function Advisor() {
+  const resetCart = useCartStore((s) => s.reset);
+  const handleNewService = async () => {
+    resetCart();
+    await clearLocalDb();
+  };
+
   return (
     <div>
-      <h1 className="font-serif text-2xl">Advisor Area</h1>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="font-serif text-2xl">Advisor Area</h1>
+        <button
+          onClick={handleNewService}
+          className="bg-primary text-background px-4 py-2 rounded"
+        >
+          Nouveau service
+        </button>
+      </div>
+      <nav className="flex gap-4 border-b mb-4">
+        <NavLink to="catalogue">Catalogue</NavLink>
+        <NavLink to="favoris">Favoris</NavLink>
+        <NavLink to="tableau">Tableau de bord</NavLink>
+        <NavLink to="historique">Historique</NavLink>
+      </nav>
+      <Routes>
+        <Route path="/" element={<AdvisorCatalog />} />
+        <Route path="catalogue" element={<AdvisorCatalog />} />
+        <Route path="favoris" element={<AdvisorFavorites />} />
+        <Route path="tableau" element={<AdvisorDashboard />} />
+        <Route path="historique" element={<AdvisorHistory />} />
+      </Routes>
     </div>
   );
 }

--- a/web/src/pages/AdvisorCatalog.tsx
+++ b/web/src/pages/AdvisorCatalog.tsx
@@ -1,0 +1,3 @@
+export default function AdvisorCatalog() {
+  return <div>Catalogue</div>;
+}

--- a/web/src/pages/AdvisorDashboard.tsx
+++ b/web/src/pages/AdvisorDashboard.tsx
@@ -1,0 +1,3 @@
+export default function AdvisorDashboard() {
+  return <div>Tableau de bord</div>;
+}

--- a/web/src/pages/AdvisorFavorites.tsx
+++ b/web/src/pages/AdvisorFavorites.tsx
@@ -1,0 +1,3 @@
+export default function AdvisorFavorites() {
+  return <div>Favoris</div>;
+}

--- a/web/src/pages/AdvisorHistory.tsx
+++ b/web/src/pages/AdvisorHistory.tsx
@@ -1,0 +1,3 @@
+export default function AdvisorHistory() {
+  return <div>Historique</div>;
+}

--- a/web/src/services/localDb.ts
+++ b/web/src/services/localDb.ts
@@ -1,0 +1,16 @@
+export async function clearLocalDb() {
+  try {
+    // @ts-ignore - optional dependency
+    const modName = 'dexie';
+    const { default: Dexie } = await import(/* @vite-ignore */ modName);
+    const db = new Dexie('lollyspace');
+    await db.delete();
+  } catch (_) {
+    if (typeof indexedDB !== 'undefined') {
+      await new Promise((resolve) => {
+        const req = indexedDB.deleteDatabase('lollyspace');
+        req.onsuccess = req.onerror = req.onblocked = () => resolve(undefined);
+      });
+    }
+  }
+}

--- a/web/src/stores/cart.ts
+++ b/web/src/stores/cart.ts
@@ -9,6 +9,7 @@ export interface CartItem {
 interface CartState {
   items: CartItem[];
   add: (item: { id: number; name: string }) => void;
+  reset: () => void;
 }
 
 export const useCartStore = create<CartState>((set) => ({
@@ -25,4 +26,5 @@ export const useCartStore = create<CartState>((set) => ({
       }
       return { items: [...state.items, { ...item, quantity: 1 }] };
     }),
+  reset: () => set({ items: [] }),
 }));


### PR DESCRIPTION
## Summary
- add Advisor area with Catalogue/Favoris/Tableau de bord/Historique tabs and reset caches button
- include Zustand reset logic and local IndexedDB/Dexie clear helper
- implement `checkout_advisor` edge function with zod validation and transactional order creation

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d259d234832bbdc2b21ee53827d3