### PR TITLE
Add admin stock tracking and import

### DIFF
--- a/edge-functions/stock_import/index.ts
+++ b/edge-functions/stock_import/index.ts
@@ -1,0 +1,57 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import postgres from "https://deno.land/x/postgresjs@v3.3.3/mod.js";
+import * as XLSX from "https://esm.sh/xlsx@0.18.5";
+
+const sql = postgres(Deno.env.get("DATABASE_URL")!, { ssl: "require" });
+
+serve(async (req) => {
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+    const importDate = form.get("date");
+    const supplier = form.get("supplier");
+    const blNumber = form.get("bl_number");
+
+    if (
+      !(file instanceof File) ||
+      typeof importDate !== "string" ||
+      typeof supplier !== "string" ||
+      typeof blNumber !== "string"
+    ) {
+      return new Response(JSON.stringify({ error: "Invalid form data" }), {
+        headers: { "Content-Type": "application/json" },
+        status: 400,
+      });
+    }
+
+    const array = await file.arrayBuffer();
+    const workbook = XLSX.read(array, { type: "array" });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    const rows = XLSX.utils.sheet_to_json(sheet) as { variant_code: string; stock_qty: number }[];
+
+    await sql.begin(async (tx) => {
+      await tx`
+        insert into stock_imports (import_date, supplier, bl_number)
+        values (${importDate}, ${supplier}, ${blNumber})
+      `;
+      for (const r of rows) {
+        if (!r.variant_code || typeof r.stock_qty !== "number") continue;
+        await tx`
+          update product_variants
+          set stock_qty = ${r.stock_qty}, updated_at = now()
+          where variant_code = ${r.variant_code}
+        `;
+      }
+    });
+
+    return new Response(JSON.stringify({ imported: rows.length }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: err.message }), {
+      headers: { "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});

--- a/supabase/migrations/20250809020000_stock_imports.sql
+++ b/supabase/migrations/20250809020000_stock_imports.sql
@@ -1,0 +1,15 @@
+-- Table for tracking stock imports
+create table public.stock_imports (
+  id bigserial primary key,
+  import_date date not null,
+  supplier text not null,
+  bl_number text not null,
+  created_at timestamptz default now()
+);
+
+alter table public.stock_imports enable row level security;
+
+create policy "stock_imports_admin_all" on public.stock_imports
+  for all
+  using (current_setting('request.jwt.claim.role', true) = 'admin')
+  with check (current_setting('request.jwt.claim.role', true) = 'admin');

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import Advisor from './pages/Advisor';
 import Admin from './pages/Admin';
 import AdminProducts from './pages/AdminProducts';
 import AdminPromotions from './pages/AdminPromotions';
+import AdminStocks from './pages/AdminStocks';
 
 export default function App() {
   return (
@@ -23,6 +24,7 @@ export default function App() {
           <Route path="/admin" element={<Admin />} />
           <Route path="/admin/products" element={<AdminProducts />} />
           <Route path="/admin/promotions" element={<AdminPromotions />} />
+          <Route path="/admin/stocks" element={<AdminStocks />} />
           </Routes>
         </main>
       </div>

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -56,6 +56,7 @@ export default function Admin() {
       <nav className="mt-4 flex gap-4">
         <Link to="/admin/products">Produits</Link>
         <Link to="/admin/promotions">Promotions</Link>
+        <Link to="/admin/stocks">Stocks</Link>
       </nav>
       <div className="mt-8 grid gap-8 md:grid-cols-2">
         <div className="w-full h-64">

--- a/web/src/pages/AdminStocks.tsx
+++ b/web/src/pages/AdminStocks.tsx
@@ -1,0 +1,72 @@
+import { useProductVariants, importStock, ProductVariant } from '../services/stock';
+import { useState } from 'react';
+
+export default function AdminStocks() {
+  const { data: variants, refetch } = useProductVariants();
+  const [loading, setLoading] = useState(false);
+
+  const ruptures = variants?.filter(v => v.stock_qty === 0) ?? [];
+  const low = variants?.filter(v => v.stock_qty > 0 && v.stock_qty < v.stock_min) ?? [];
+  const ok = variants?.filter(v => v.stock_qty >= v.stock_min) ?? [];
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    setLoading(true);
+    try {
+      await importStock(form);
+      await refetch();
+      e.currentTarget.reset();
+    } catch (err) {
+      alert('Import failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function renderList(title: string, list: ProductVariant[]) {
+    return (
+      <div className="mt-6">
+        <h2 className="font-semibold">{title}</h2>
+        <ul className="mt-2 flex flex-col gap-1">
+          {list.map(v => (
+            <li key={v.id}>
+              {v.products.inspired_name} {v.volume_ml}ml ({v.stock_qty})
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1 className="font-serif text-2xl">Suivi des stocks</h1>
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-2 max-w-md">
+        <label className="flex flex-col">
+          Date
+          <input type="date" name="date" required className="border p-1" />
+        </label>
+        <label className="flex flex-col">
+          Fournisseur
+          <input type="text" name="supplier" required className="border p-1" />
+        </label>
+        <label className="flex flex-col">
+          N° BL
+          <input type="text" name="bl_number" required className="border p-1" />
+        </label>
+        <label className="flex flex-col">
+          Fichier Excel
+          <input type="file" name="file" accept=".xlsx,.xls" required />
+        </label>
+        <button type="submit" disabled={loading} className="mt-2 px-4 py-2 bg-primary text-background">
+          {loading ? 'Import...' : 'Importer'}
+        </button>
+      </form>
+
+      {renderList('Ruptures', ruptures)}
+      {renderList('Stock minimum', low)}
+      {renderList('OK', ok)}
+    </div>
+  );
+}

--- a/web/src/services/stock.ts
+++ b/web/src/services/stock.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface ProductVariant {
+  id: number;
+  variant_code: string;
+  volume_ml: number;
+  stock_qty: number;
+  stock_min: number;
+  products: { inspired_name: string };
+}
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const headers = {
+  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+};
+
+async function fetchVariants() {
+  const res = await fetch(
+    `${baseUrl}/rest/v1/product_variants?select=*,products(inspired_name)`,
+    { headers }
+  );
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as ProductVariant[];
+}
+
+export function useProductVariants() {
+  return useQuery({ queryKey: ['product_variants'], queryFn: fetchVariants });
+}
+
+export async function importStock(data: FormData) {
+  const res = await fetch(`${baseUrl}/functions/v1/stock_import`, {
+    method: 'POST',
+    headers,
+    body: data,
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `stock_imports` table and edge function to ingest Excel uploads
- add stock service and admin page to show min/out/ok statuses
- wire new stocks page into admin navigation and routes

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d4758f34832bb5a5df751f255193