### PR TITLE
feat: add promotion management and application

### DIFF
--- a/edge-functions/apply_promotions/index.ts
+++ b/edge-functions/apply_promotions/index.ts
@@ -1,0 +1,76 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import postgres from "https://deno.land/x/postgresjs@v3.3.3/mod.js";
+import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
+
+const sql = postgres(Deno.env.get("DATABASE_URL")!, { ssl: "require" });
+
+const itemSchema = z.object({
+  product_variant_id: z.number().int(),
+  quantity: z.number().int().positive(),
+  unit_price_tnd: z.number().nonnegative(),
+});
+
+const bodySchema = z.object({
+  items: z.array(itemSchema),
+});
+
+type Item = z.infer<typeof itemSchema> & { discount_tnd: number };
+
+serve(async (req) => {
+  try {
+    const { items } = bodySchema.parse(await req.json());
+    const result: Item[] = items.map((i) => ({ ...i, discount_tnd: 0 }));
+
+    const promotions = await sql`
+      select type, condition_json
+      from promotions
+      where active = true and now() between starts_at and ends_at
+    `;
+
+    for (const p of promotions.filter((p: any) => p.type === 'pack')) {
+      const ids: number[] = p.condition_json.product_variant_ids || [];
+      const price: number = p.condition_json.price;
+      const matches = ids.map((id) =>
+        result.find((r) => r.product_variant_id === id)
+      );
+      if (matches.some((m) => !m)) continue;
+      const packCount = Math.min(...matches.map((m) => m!.quantity));
+      if (packCount <= 0) continue;
+      const sumPrice = matches.reduce((s, m) => s + m!.unit_price_tnd, 0);
+      const discountPerPack = sumPrice - price;
+      const discountPerItem = discountPerPack / ids.length;
+      matches.forEach((m) => {
+        m!.discount_tnd += (discountPerItem * packCount) / m!.quantity;
+      });
+    }
+
+    for (const p of promotions.filter((p: any) => p.type === 'two_plus_one')) {
+      const id = p.condition_json.product_variant_id;
+      const item = result.find((r) => r.product_variant_id === id);
+      if (!item) continue;
+      const freeCount = Math.floor(item.quantity / 3);
+      if (freeCount <= 0) continue;
+      const totalDiscount = freeCount * item.unit_price_tnd;
+      item.discount_tnd += totalDiscount / item.quantity;
+    }
+
+    for (const p of promotions.filter((p: any) => p.type === 'discount')) {
+      const id = p.condition_json.product_variant_id;
+      const percent = p.condition_json.percent;
+      const item = result.find((r) => r.product_variant_id === id);
+      if (!item) continue;
+      item.discount_tnd += item.unit_price_tnd * (percent / 100);
+    }
+
+    return new Response(JSON.stringify({ items: result }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (err) {
+    const message = err instanceof z.ZodError ? err.errors : err.message;
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/pages/AdminPromotions.tsx
+++ b/web/src/pages/AdminPromotions.tsx
@@ -1,7 +1,179 @@
-import { usePromotions, updatePromotion, Promotion } from '../services/promotions';
+import {
+  usePromotions,
+  updatePromotion,
+  savePromotion,
+  Promotion,
+  PromotionInput,
+} from '../services/promotions';
+import { useState } from 'react';
+
+function PromotionForm({
+  promotion,
+  onClose,
+}: {
+  promotion?: Promotion;
+  onClose: () => void;
+}) {
+  const [type, setType] = useState<PromotionInput['type']>(
+    promotion?.type || 'discount',
+  );
+  const [productVariantId, setProductVariantId] = useState(
+    promotion?.condition_json?.product_variant_id || '',
+  );
+  const [percent, setPercent] = useState(
+    promotion?.condition_json?.percent || '',
+  );
+  const [packIds, setPackIds] = useState(
+    promotion?.condition_json?.product_variant_ids?.join(',') || '',
+  );
+  const [packPrice, setPackPrice] = useState(
+    promotion?.condition_json?.price || '',
+  );
+  const [startsAt, setStartsAt] = useState(
+    promotion ? promotion.starts_at.slice(0, 10) : '',
+  );
+  const [endsAt, setEndsAt] = useState(
+    promotion ? promotion.ends_at.slice(0, 10) : '',
+  );
+  const [active, setActive] = useState(promotion?.active ?? true);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    let condition_json: any;
+    if (type === 'discount') {
+      condition_json = {
+        product_variant_id: Number(productVariantId),
+        percent: Number(percent),
+      };
+    } else if (type === 'two_plus_one') {
+      condition_json = { product_variant_id: Number(productVariantId) };
+    } else {
+      condition_json = {
+        product_variant_ids: packIds
+          .split(',')
+          .map((id) => Number(id.trim()))
+          .filter(Boolean),
+        price: Number(packPrice),
+      };
+    }
+    await savePromotion({
+      id: promotion?.id,
+      type,
+      condition_json,
+      starts_at: new Date(startsAt).toISOString(),
+      ends_at: new Date(endsAt).toISOString(),
+      active,
+    });
+    onClose();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-2">
+      <label>
+        Type
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value as PromotionInput['type'])}
+          className="border p-1 ml-2"
+          disabled={!!promotion}
+        >
+          <option value="discount">discount</option>
+          <option value="two_plus_one">2+1</option>
+          <option value="pack">pack</option>
+        </select>
+      </label>
+      {(type === 'discount' || type === 'two_plus_one') && (
+        <label>
+          Variant ID
+          <input
+            type="number"
+            value={productVariantId}
+            onChange={(e) => setProductVariantId(e.target.value)}
+            className="border p-1 ml-2"
+            required
+          />
+        </label>
+      )}
+      {type === 'discount' && (
+        <label>
+          Percent
+          <input
+            type="number"
+            value={percent}
+            onChange={(e) => setPercent(e.target.value)}
+            className="border p-1 ml-2"
+            required
+          />
+        </label>
+      )}
+      {type === 'pack' && (
+        <>
+          <label>
+            Variant IDs (comma)
+            <input
+              type="text"
+              value={packIds}
+              onChange={(e) => setPackIds(e.target.value)}
+              className="border p-1 ml-2"
+              required
+            />
+          </label>
+          <label>
+            Pack price
+            <input
+              type="number"
+              value={packPrice}
+              onChange={(e) => setPackPrice(e.target.value)}
+              className="border p-1 ml-2"
+              required
+            />
+          </label>
+        </>
+      )}
+      <label>
+        Début
+        <input
+          type="date"
+          value={startsAt}
+          onChange={(e) => setStartsAt(e.target.value)}
+          className="border p-1 ml-2"
+          required
+        />
+      </label>
+      <label>
+        Fin
+        <input
+          type="date"
+          value={endsAt}
+          onChange={(e) => setEndsAt(e.target.value)}
+          className="border p-1 ml-2"
+          required
+        />
+      </label>
+      <label>
+        Actif
+        <input
+          type="checkbox"
+          checked={active}
+          onChange={(e) => setActive(e.target.checked)}
+          className="ml-2"
+        />
+      </label>
+      <div className="flex gap-2">
+        <button type="submit" className="px-2 py-1 bg-primary text-background">
+          Enregistrer
+        </button>
+        <button type="button" onClick={onClose} className="px-2 py-1 border">
+          Annuler
+        </button>
+      </div>
+    </form>
+  );
+}
 
 export default function AdminPromotions() {
   const { data: promotions, refetch } = usePromotions();
+  const [editing, setEditing] = useState<Promotion | null | undefined>(undefined);
 
   async function toggle(promo: Promotion) {
     await updatePromotion(promo.id, !promo.active);
@@ -11,13 +183,41 @@ export default function AdminPromotions() {
   return (
     <div>
       <h1 className="font-serif text-2xl">Gestion des promotions</h1>
+      {editing !== undefined && (
+        <PromotionForm
+          promotion={editing || undefined}
+          onClose={() => {
+            setEditing(undefined);
+            refetch();
+          }}
+        />
+      )}
+      {editing === undefined && (
+        <button
+          onClick={() => setEditing(null)}
+          className="mt-4 px-2 py-1 bg-primary text-background"
+        >
+          Nouvelle promotion
+        </button>
+      )}
       <ul className="mt-4 flex flex-col gap-1">
-        {promotions?.map(p => (
+        {promotions?.map((p) => (
           <li key={p.id} className="flex justify-between">
             <span>{p.type}</span>
-            <button onClick={() => toggle(p)} className="text-sm text-primary">
-              {p.active ? 'Désactiver' : 'Activer'}
-            </button>
+            <div className="flex gap-2">
+              <button
+                onClick={() => toggle(p)}
+                className="text-sm text-primary"
+              >
+                {p.active ? 'Désactiver' : 'Activer'}
+              </button>
+              <button
+                onClick={() => setEditing(p)}
+                className="text-sm text-primary"
+              >
+                Éditer
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/web/src/services/checkout.ts
+++ b/web/src/services/checkout.ts
@@ -1,0 +1,27 @@
+import { applyPromotions, PromotionItem } from './promotions';
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const headers = {
+  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+  'Content-Type': 'application/json',
+};
+
+export async function checkoutAdvisor(payload: {
+  advisor_id: string;
+  client:
+    | { id: string }
+    | { first_name: string; last_name: string; phone: string };
+  items: PromotionItem[];
+}) {
+  const promo = await applyPromotions(payload.items);
+  const res = await fetch(`${baseUrl}/functions/v1/checkout_advisor`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ ...payload, items: promo.items }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json();
+}

--- a/web/src/services/promotions.ts
+++ b/web/src/services/promotions.ts
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
+import { PromotionId } from '@/types/promotion';
 
 export interface Promotion {
-  id: number;
+  id: PromotionId;
   type: string;
   condition_json: any;
   starts_at: string;
@@ -10,7 +11,7 @@ export interface Promotion {
 }
 
 export interface PromotionInput {
-  id?: number;
+  id?: PromotionId;
   type: string;
   condition_json: any;
   starts_at: string;
@@ -37,11 +38,21 @@ export function usePromotions() {
   return useQuery({ queryKey: ['promotions'], queryFn: fetchPromotions });
 }
 
-export async function updatePromotion(id: number, active: boolean) {
+export async function updatePromotion(id: PromotionId, active: boolean) {
   const res = await fetch(`${baseUrl}/rest/v1/promotions?id=eq.${id}`, {
     method: 'PATCH',
     headers,
     body: JSON.stringify({ active }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+}
+
+export async function deletePromotion(id: PromotionId) {
+  const res = await fetch(`${baseUrl}/rest/v1/promotions?id=eq.${id}`, {
+    method: 'DELETE',
+    headers,
   });
   if (!res.ok) {
     throw new Error(await res.text());

--- a/web/src/services/promotions.ts
+++ b/web/src/services/promotions.ts
@@ -3,6 +3,16 @@ import { useQuery } from '@tanstack/react-query';
 export interface Promotion {
   id: number;
   type: string;
+  condition_json: any;
+  starts_at: string;
+  ends_at: string;
+  active: boolean;
+}
+
+export interface PromotionInput {
+  id?: number;
+  type: string;
+  condition_json: any;
   starts_at: string;
   ends_at: string;
   active: boolean;
@@ -36,5 +46,39 @@ export async function updatePromotion(id: number, active: boolean) {
   if (!res.ok) {
     throw new Error(await res.text());
   }
+}
+
+export async function savePromotion(promo: PromotionInput) {
+  const method = promo.id ? 'PATCH' : 'POST';
+  const url = promo.id
+    ? `${baseUrl}/rest/v1/promotions?id=eq.${promo.id}`
+    : `${baseUrl}/rest/v1/promotions`;
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: JSON.stringify(promo),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+}
+
+export interface PromotionItem {
+  product_variant_id: number;
+  quantity: number;
+  unit_price_tnd: number;
+  discount_tnd?: number;
+}
+
+export async function applyPromotions(items: PromotionItem[]) {
+  const res = await fetch(`${baseUrl}/functions/v1/apply_promotions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ items }),
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as { items: PromotionItem[] };
 }
 

--- a/web/src/types/promotion.ts
+++ b/web/src/types/promotion.ts
@@ -1,0 +1,14 @@
+export type PromotionType = 'discount' | '2+1' | 'pack';
+
+export type PromotionId = string;
+
+export interface Promotion {
+  id: PromotionId;
+  name: string;
+  type: PromotionType;
+  active: boolean;
+  startsAt?: string; // ISO
+  endsAt?: string;   // ISO
+  percentOff?: number;    // pour discount
+  packSize?: number;      // pour pack
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -8,12 +8,17 @@
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "noImplicitAny": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add Edge Function to apply promotions with priority pack > 2+1 > discount
- extend admin UI and services for creating and editing promotions
- apply promotions during advisor checkout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897d7ca48d4832bad2658e015ce122f