### PR TITLE
Compute order commissions and add admin payments module

### DIFF
--- a/edge-functions/checkout_advisor/index.ts
+++ b/edge-functions/checkout_advisor/index.ts
@@ -80,6 +80,15 @@ serve(async (req) => {
 
       return { order_id: orderId, order_code: code, client_id: clientId };
     });
+    try {
+      await fetch(new URL('/compute_commissions', req.url).toString(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: result.order_id }),
+      });
+    } catch (_) {
+      // ignore commission errors
+    }
 
     return new Response(JSON.stringify(result), {
       headers: { "Content-Type": "application/json" },

--- a/edge-functions/compute_commissions/index.ts
+++ b/edge-functions/compute_commissions/index.ts
@@ -1,0 +1,56 @@
+import { serve } from "https://deno.land/std@0.203.0/http/server.ts";
+import { z } from "https://deno.land/x/zod@v3.22.2/mod.ts";
+import postgres from "https://deno.land/x/postgresjs@v3.3.3/mod.js";
+
+const sql = postgres(Deno.env.get("DATABASE_URL")!, { ssl: "require" });
+
+const bodySchema = z.object({
+  order_id: z.number().int(),
+});
+
+serve(async (req) => {
+  try {
+    const { order_id } = bodySchema.parse(await req.json());
+
+    const order = await sql`
+      select o.id, o.user_id as referee_id, o.advisor_id as l1, o.total_tnd,
+             p.referrer_id as l2, p2.referrer_id as l3
+      from orders o
+      left join profiles p on p.id = o.advisor_id
+      left join profiles p2 on p2.id = p.referrer_id
+      where o.id = ${order_id}
+    `;
+    if (order.length === 0) {
+      throw new Error("Order not found");
+    }
+
+    const data = order[0];
+    const referrers = [data.l1, data.l2, data.l3];
+    const rates = [0.1, 0.05, 0.02];
+
+    await sql.begin(async (tx) => {
+      for (let i = 0; i < 3; i++) {
+        const referrer = referrers[i];
+        if (referrer) {
+          await tx`
+            insert into commissions (referrer_id, referee_id, order_id, level, amount_tnd)
+            values (${referrer}, ${data.referee_id}, ${order_id}, ${i + 1}, ${
+              data.total_tnd * rates[i]
+            })
+          `;
+        }
+      }
+    });
+
+    return new Response(JSON.stringify({ status: "ok" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof z.ZodError ? err.errors : err.message;
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { "Content-Type": "application/json" },
+      status: 400,
+    });
+  }
+});
+

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import Admin from './pages/Admin';
 import AdminProducts from './pages/AdminProducts';
 import AdminPromotions from './pages/AdminPromotions';
 import AdminStocks from './pages/AdminStocks';
+import AdminCommissions from './pages/AdminCommissions';
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="/admin/products" element={<AdminProducts />} />
           <Route path="/admin/promotions" element={<AdminPromotions />} />
           <Route path="/admin/stocks" element={<AdminStocks />} />
+          <Route path="/admin/commissions" element={<AdminCommissions />} />
           </Routes>
         </main>
       </div>

--- a/web/src/pages/Admin.tsx
+++ b/web/src/pages/Admin.tsx
@@ -57,6 +57,7 @@ export default function Admin() {
         <Link to="/admin/products">Produits</Link>
         <Link to="/admin/promotions">Promotions</Link>
         <Link to="/admin/stocks">Stocks</Link>
+        <Link to="/admin/commissions">Commissions</Link>
       </nav>
       <div className="mt-8 grid gap-8 md:grid-cols-2">
         <div className="w-full h-64">

--- a/web/src/pages/AdminCommissions.tsx
+++ b/web/src/pages/AdminCommissions.tsx
@@ -1,0 +1,33 @@
+import { useCommissions, payCommission, Commission } from '../services/commissions';
+
+export default function AdminCommissions() {
+  const { data: commissions, refetch } = useCommissions();
+
+  async function handlePay(c: Commission) {
+    await payCommission(c);
+    refetch();
+  }
+
+  return (
+    <div>
+      <h1 className="font-serif text-2xl">Commissions</h1>
+      <ul className="mt-4 flex flex-col gap-2">
+        {commissions?.map(c => (
+          <li key={c.id} className="flex justify-between">
+            <span>
+              Niveau {c.level} – {c.amount_tnd} TND
+            </span>
+            {c.commission_payment_items && c.commission_payment_items.length > 0 ? (
+              <span className="text-sm text-gray-500">Payée</span>
+            ) : (
+              <button onClick={() => handlePay(c)} className="text-sm text-green-600">
+                Payer
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/web/src/services/commissions.ts
+++ b/web/src/services/commissions.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface Commission {
+  id: number;
+  referrer_id: string | null;
+  referee_id: string | null;
+  order_id: number | null;
+  level: number;
+  amount_tnd: number;
+  created_at: string;
+  commission_payment_items?: { payment_id: number }[];
+}
+
+const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const headers = {
+  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+  'Content-Type': 'application/json',
+};
+
+async function fetchCommissions() {
+  const url = `${baseUrl}/rest/v1/commissions?select=*,commission_payment_items(payment_id)`;
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return (await res.json()) as Commission[];
+}
+
+export function useCommissions() {
+  return useQuery({ queryKey: ['commissions'], queryFn: fetchCommissions });
+}
+
+export async function payCommission(c: Commission) {
+  const paymentRes = await fetch(`${baseUrl}/rest/v1/commission_payments`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ payee_id: c.referrer_id, amount_tnd: c.amount_tnd }),
+  });
+  if (!paymentRes.ok) {
+    throw new Error(await paymentRes.text());
+  }
+  const [payment] = (await paymentRes.json()) as { id: number }[];
+  await fetch(`${baseUrl}/rest/v1/commission_payment_items`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      commission_id: c.id,
+      payment_id: payment.id,
+      amount_tnd: c.amount_tnd,
+    }),
+  });
+}
+


### PR DESCRIPTION
## Summary
- compute L1-L3 commissions in new edge function and invoke after advisor checkout
- add admin UI and services to view commissions and record payments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6897dde99630832bb8d29449d082ea5d