### PR TITLE
chore(ci): single-writer; sync lock; stable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
           cache: 'npm'
+          cache-dependency-path: web/package-lock.json
       - name: Install (CI)
         run: npm ci
       - name: Lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,21 @@
-name: CI
-
+name: build
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
+  push: { branches: [ main ] }
+  pull_request: { branches: [ main ] }
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: web
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-      - run: npm ci
-      - run: npm run build
+          node-version: '18'
+          cache: 'npm'
+      - name: Install (CI)
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Typecheck
+        run: npm run typecheck --if-present
+      - name: Build
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 web/node_modules/
 dist/
 web/dist/
+# Allow npm lockfile
+!web/package-lock.json
 .env
 .env.local
 web/.env


### PR DESCRIPTION
## Summary
- rewrite build workflow to run install, lint, typecheck and build with Node 18

## Testing
- `npm ci`
- `npm run lint --if-present`
- `npm run typecheck --if-present`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897e6732188832bb287433c61df1ec5