### PR TITLE
feat: advisor catalog and cart

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "lollyspace-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/seed_commissions.test.js && node tests/commissions_export.test.js"
+    "test": "node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js"
   }
 }

--- a/tests/checkout.test.js
+++ b/tests/checkout.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+
+const calls = [];
+
+global.fetch = async (url, options) => {
+  calls.push({ url, options });
+  if (url.toString().includes('apply_promotions')) {
+    const body = JSON.parse(options.body);
+    return { ok: true, json: async () => ({ items: body.items }) };
+  }
+  if (url.toString().includes('checkout_advisor')) {
+    return { ok: true, json: async () => ({ id: 99 }) };
+  }
+  throw new Error('unexpected url');
+};
+
+async function checkoutAdvisor(payload) {
+  const promo = await global.fetch('apply_promotions', {
+    method: 'POST',
+    body: JSON.stringify({ items: payload.items }),
+  }).then((r) => r.json());
+  const res = await global.fetch('checkout_advisor', {
+    method: 'POST',
+    body: JSON.stringify({ ...payload, items: promo.items }),
+  });
+  if (!res.ok) throw new Error('network');
+  return res.json();
+}
+
+(async () => {
+  const payload = {
+    advisor_id: 'A1',
+    client: { id: 'C1' },
+    items: [
+      {
+        product_variant_id: 1,
+        quantity: 2,
+        unit_price_tnd: 10,
+        discount_tnd: 0,
+      },
+    ],
+  };
+  const res = await checkoutAdvisor(payload);
+  assert.strictEqual(res.id, 99);
+  const checkoutCall = calls.find((c) =>
+    c.url.toString().includes('checkout_advisor'),
+  );
+  const sent = JSON.parse(checkoutCall.options.body);
+  assert.strictEqual(sent.items[0].product_variant_id, 1);
+  assert.strictEqual(sent.items[0].unit_price_tnd, 10);
+  assert.strictEqual(sent.items[0].discount_tnd, 0);
+  console.log('All tests passed');
+})();
+

--- a/web/src/pages/Advisor.tsx
+++ b/web/src/pages/Advisor.tsx
@@ -3,6 +3,7 @@ import AdvisorCatalog from './AdvisorCatalog';
 import AdvisorFavorites from './AdvisorFavorites';
 import AdvisorDashboard from './AdvisorDashboard';
 import AdvisorHistory from './AdvisorHistory';
+import AdvisorCart from './AdvisorCart';
 import { useCartStore } from '../stores/cart';
 import { clearLocalDb } from '../services/localDb';
 
@@ -27,6 +28,7 @@ export default function Advisor() {
       <nav className="flex gap-4 border-b mb-4">
         <NavLink to="catalogue">Catalogue</NavLink>
         <NavLink to="favoris">Favoris</NavLink>
+        <NavLink to="panier">Panier</NavLink>
         <NavLink to="tableau">Tableau de bord</NavLink>
         <NavLink to="historique">Historique</NavLink>
       </nav>
@@ -34,6 +36,7 @@ export default function Advisor() {
         <Route path="/" element={<AdvisorCatalog />} />
         <Route path="catalogue" element={<AdvisorCatalog />} />
         <Route path="favoris" element={<AdvisorFavorites />} />
+        <Route path="panier" element={<AdvisorCart />} />
         <Route path="tableau" element={<AdvisorDashboard />} />
         <Route path="historique" element={<AdvisorHistory />} />
       </Routes>

--- a/web/src/pages/AdvisorCart.tsx
+++ b/web/src/pages/AdvisorCart.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { useCartStore } from '@/stores/cart';
+import { checkoutAdvisorWithOffline } from '@/services/checkout';
+
+export default function AdvisorCart() {
+  const { items, update, remove, reset } = useCartStore();
+  const [loading, setLoading] = useState(false);
+  const handleCheckout = async () => {
+    setLoading(true);
+    try {
+      await checkoutAdvisorWithOffline({
+        advisor_id: 'A1',
+        client: { id: 'C1' },
+        items: items.map((i) => ({
+          product_variant_id: i.product_variant_id,
+          quantity: i.quantity,
+          unit_price_tnd: i.price_tnd,
+          discount_tnd: i.discount_tnd,
+        })),
+      });
+      reset();
+    } catch (e) {
+      // in offline mode, checkoutAdvisorWithOffline will queue the sale
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="font-serif text-xl mb-4">Panier</h2>
+      <div className="flex flex-col gap-2">
+        {items.map((i) => (
+          <div
+            key={i.product_variant_id}
+            className="flex items-center justify-between border p-2 rounded"
+          >
+            <div>
+              <p>{i.name}</p>
+              <p className="text-sm text-muted">
+                {i.quantity} × {i.price_tnd} TND
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => update(i.product_variant_id, i.quantity - 1)}
+                className="px-2 py-1 border rounded"
+              >
+                -
+              </button>
+              <span>{i.quantity}</span>
+              <button
+                onClick={() => update(i.product_variant_id, i.quantity + 1)}
+                className="px-2 py-1 border rounded"
+              >
+                +
+              </button>
+              <button
+                onClick={() => remove(i.product_variant_id)}
+                className="px-2 py-1 border rounded text-red-500"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+      <button
+        disabled={items.length === 0 || loading}
+        onClick={handleCheckout}
+        className="mt-4 px-4 py-2 bg-primary text-background rounded"
+      >
+        Finaliser
+      </button>
+    </div>
+  );
+}
+

--- a/web/src/pages/AdvisorCart.tsx
+++ b/web/src/pages/AdvisorCart.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useCartStore } from '@/stores/cart';
 import { checkoutAdvisorWithOffline } from '@/services/checkout';
+import type { PromotionItem } from '@/services/promotions';
 
 export default function AdvisorCart() {
   const { items, update, remove, reset } = useCartStore();
@@ -11,7 +12,7 @@ export default function AdvisorCart() {
       await checkoutAdvisorWithOffline({
         advisor_id: 'A1',
         client: { id: 'C1' },
-        items: items.map((i) => ({
+        items: items.map<PromotionItem>((i) => ({
           product_variant_id: i.product_variant_id,
           quantity: i.quantity,
           unit_price_tnd: i.price_tnd,

--- a/web/src/pages/AdvisorCatalog.tsx
+++ b/web/src/pages/AdvisorCatalog.tsx
@@ -3,6 +3,7 @@ import SearchBarDual from '@/components/SearchBarDual';
 import VolumeButtons from '@/components/VolumeButtons';
 import { useSearchProducts, Product } from '@/services/products';
 import { useCartStore } from '@/stores/cart';
+import type { CartItem } from '@/types/cart';
 
 export default function AdvisorCatalog() {
   const [query, setQuery] = useState('');
@@ -27,13 +28,14 @@ export default function AdvisorCatalog() {
   const handleAdd = (p: Product, volume: number) => {
     // In real implementation, variant info would come from API
     const product_variant_id = Number(`${p.id}${volume}`);
-    add({
+    const item: CartItem = {
       id: p.id,
       name: p.inspired_name,
       product_variant_id,
       price_tnd: 0,
       discount_tnd: 0,
-    });
+    };
+    add(item);
   };
 
   return (

--- a/web/src/pages/AdvisorCatalog.tsx
+++ b/web/src/pages/AdvisorCatalog.tsx
@@ -1,3 +1,66 @@
+import { useState } from 'react';
+import SearchBarDual from '@/components/SearchBarDual';
+import VolumeButtons from '@/components/VolumeButtons';
+import { useSearchProducts, Product } from '@/services/products';
+import { useCartStore } from '@/stores/cart';
+
 export default function AdvisorCatalog() {
-  return <div>Catalogue</div>;
+  const [query, setQuery] = useState('');
+  const { data } = useSearchProducts(query, 1);
+  const add = useCartStore((s) => s.add);
+  const [favorites, setFavorites] = useState<number[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('favorites') || '[]');
+    } catch {
+      return [];
+    }
+  });
+
+  const toggleFavorite = (id: number) => {
+    const next = favorites.includes(id)
+      ? favorites.filter((f) => f !== id)
+      : favorites.concat(id);
+    setFavorites(next);
+    localStorage.setItem('favorites', JSON.stringify(next));
+  };
+
+  const handleAdd = (p: Product, volume: number) => {
+    // In real implementation, variant info would come from API
+    const product_variant_id = Number(`${p.id}${volume}`);
+    add({
+      id: p.id,
+      name: p.inspired_name,
+      product_variant_id,
+      price_tnd: 0,
+      discount_tnd: 0,
+    });
+  };
+
+  return (
+    <div>
+      <SearchBarDual onSearch={setQuery} />
+      <div className="mt-4 grid gap-4">
+        {data?.map((p) => (
+          <div key={p.id} className="border p-2 rounded bg-background text-foreground">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-serif">{p.inspired_name}</h3>
+                <p className="text-sm text-muted">{p.inspired_brand}</p>
+              </div>
+              <button onClick={() => toggleFavorite(p.id)}>
+                {favorites.includes(p.id) ? '★' : '☆'}
+              </button>
+            </div>
+            <div className="mt-2">
+              <VolumeButtons
+                volumes={[30, 50, 100]}
+                onSelect={(v) => handleAdd(p, v)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
+

--- a/web/src/pages/Client.tsx
+++ b/web/src/pages/Client.tsx
@@ -3,6 +3,7 @@ import ProductCard from '../components/ProductCard';
 import SearchBarDual from '../components/SearchBarDual';
 import { useSearchProducts } from '../services/products';
 import { useCartStore } from '../stores/cart';
+import type { CartItem } from '@/types/cart';
 
 export default function Client() {
   const [term, setTerm] = useState('');
@@ -20,12 +21,21 @@ export default function Client() {
       />
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {data?.map((p) => (
-          <ProductCard
-            key={p.id}
-            name={p.inspired_name}
-            brand={p.inspired_brand}
-            onAdd={() => add({ id: p.id, name: p.inspired_name })}
-          />
+            <ProductCard
+              key={p.id}
+              name={p.inspired_name}
+              brand={p.inspired_brand}
+              onAdd={() => {
+                const item: CartItem = {
+                  id: p.id,
+                  name: p.inspired_name,
+                  product_variant_id: Number(`${p.id}50`),
+                  price_tnd: 0,
+                  discount_tnd: 0,
+                };
+                add(item);
+              }}
+            />
         ))}
       </div>
       {term && (

--- a/web/src/services/checkout.ts
+++ b/web/src/services/checkout.ts
@@ -1,9 +1,13 @@
 import { applyPromotions, PromotionItem } from './promotions';
 
-const baseUrl = import.meta.env.VITE_SUPABASE_URL;
+const env =
+  typeof import.meta !== 'undefined' && (import.meta as any).env
+    ? (import.meta as any).env
+    : process.env;
+const baseUrl = env.VITE_SUPABASE_URL as string;
 const headers = {
-  apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
-  Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+  apikey: env.VITE_SUPABASE_ANON_KEY as string,
+  Authorization: `Bearer ${env.VITE_SUPABASE_ANON_KEY}`,
   'Content-Type': 'application/json',
 };
 
@@ -25,3 +29,49 @@ export async function checkoutAdvisor(payload: {
   }
   return res.json();
 }
+
+const OFFLINE_KEY = 'offline-sales';
+
+function saveOffline(payload: any) {
+  if (typeof localStorage === 'undefined') return;
+  const queue = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]');
+  queue.push(payload);
+  localStorage.setItem(OFFLINE_KEY, JSON.stringify(queue));
+}
+
+export async function syncOfflineSales() {
+  if (typeof localStorage === 'undefined') return;
+  const queue = JSON.parse(localStorage.getItem(OFFLINE_KEY) || '[]');
+  if (queue.length === 0) return;
+  const remaining: any[] = [];
+  for (const sale of queue) {
+    try {
+      await checkoutAdvisor(sale);
+    } catch (e) {
+      remaining.push(sale);
+    }
+  }
+  localStorage.setItem(OFFLINE_KEY, JSON.stringify(remaining));
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', () => {
+    syncOfflineSales();
+  });
+}
+
+export async function checkoutAdvisorWithOffline(payload: {
+  advisor_id: string;
+  client:
+    | { id: string }
+    | { first_name: string; last_name: string; phone: string };
+  items: PromotionItem[];
+}) {
+  try {
+    return await checkoutAdvisor(payload);
+  } catch (e) {
+    saveOffline(payload);
+    throw e;
+  }
+}
+

--- a/web/src/stores/cart.ts
+++ b/web/src/stores/cart.ts
@@ -1,14 +1,27 @@
 import { create } from 'zustand';
 
 export interface CartItem {
-  id: number;
+  id: number; // product id
   name: string;
+  product_variant_id: number;
+  price_tnd: number;
+  discount_tnd?: number;
   quantity: number;
 }
 
 interface CartState {
   items: CartItem[];
-  add: (item: { id: number; name: string }) => void;
+  add: (
+    item: {
+      id: number;
+      name: string;
+      product_variant_id: number;
+      price_tnd: number;
+      discount_tnd?: number;
+    },
+  ) => void;
+  update: (product_variant_id: number, quantity: number) => void;
+  remove: (product_variant_id: number) => void;
   reset: () => void;
 }
 
@@ -16,15 +29,33 @@ export const useCartStore = create<CartState>((set) => ({
   items: [],
   add: (item) =>
     set((state) => {
-      const existing = state.items.find((i) => i.id === item.id);
+      const existing = state.items.find(
+        (i) => i.product_variant_id === item.product_variant_id,
+      );
       if (existing) {
         return {
           items: state.items.map((i) =>
-            i.id === item.id ? { ...i, quantity: i.quantity + 1 } : i
+            i.product_variant_id === item.product_variant_id
+              ? { ...i, quantity: i.quantity + 1 }
+              : i,
           ),
         };
       }
       return { items: [...state.items, { ...item, quantity: 1 }] };
     }),
+  update: (product_variant_id, quantity) =>
+    set((state) => ({
+      items: state.items
+        .map((i) =>
+          i.product_variant_id === product_variant_id ? { ...i, quantity } : i,
+        )
+        .filter((i) => i.quantity > 0),
+    })),
+  remove: (product_variant_id) =>
+    set((state) => ({
+      items: state.items.filter(
+        (i) => i.product_variant_id !== product_variant_id,
+      ),
+    })),
   reset: () => set({ items: [] }),
 }));

--- a/web/src/stores/cart.ts
+++ b/web/src/stores/cart.ts
@@ -1,25 +1,9 @@
 import { create } from 'zustand';
-
-export interface CartItem {
-  id: number; // product id
-  name: string;
-  product_variant_id: number;
-  price_tnd: number;
-  discount_tnd?: number;
-  quantity: number;
-}
+import type { CartItem } from '@/types/cart';
 
 interface CartState {
-  items: CartItem[];
-  add: (
-    item: {
-      id: number;
-      name: string;
-      product_variant_id: number;
-      price_tnd: number;
-      discount_tnd?: number;
-    },
-  ) => void;
+  items: (CartItem & { quantity: number })[];
+  add: (item: CartItem) => void;
   update: (product_variant_id: number, quantity: number) => void;
   remove: (product_variant_id: number) => void;
   reset: () => void;

--- a/web/src/types/cart.ts
+++ b/web/src/types/cart.ts
@@ -1,0 +1,7 @@
+export interface CartItem {
+  id: number;
+  name: string;
+  product_variant_id: number;
+  price_tnd: number;
+  discount_tnd?: number;
+}

--- a/web/src/types/product.ts
+++ b/web/src/types/product.ts
@@ -1,0 +1,7 @@
+export interface ProductVariant {
+  id: number;
+  product_id: number;
+  size_ml: number;
+  price_tnd: number;
+  discount_tnd?: number;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
@@ -18,7 +18,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- implement advisor catalog with search, volume selection, local favorites, and add to cart
- extend cart store and create cart screen with quantity editing and checkout
- add offline-aware checkout service and basic sale simulation test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f4f294c4832b9bcca8ae2a6b1826