### PR TITLE
Add referral chain and seed activation

### DIFF
--- a/edge-functions/compute_commissions/index.ts
+++ b/edge-functions/compute_commissions/index.ts
@@ -13,11 +13,12 @@ serve(async (req) => {
     const { order_id } = bodySchema.parse(await req.json());
 
     const order = await sql`
-      select o.id, o.user_id as referee_id, o.advisor_id as l1, o.total_tnd,
-             p.referrer_id as l2, p2.referrer_id as l3
+      select o.id, o.user_id as referee_id, o.total_tnd,
+             p.referrer_id as l1, p1.referrer_id as l2, p2.referrer_id as l3
       from orders o
-      left join profiles p on p.id = o.advisor_id
-      left join profiles p2 on p2.id = p.referrer_id
+      left join profiles p on p.id = o.user_id
+      left join profiles p1 on p1.id = p.referrer_id
+      left join profiles p2 on p2.id = p1.referrer_id
       where o.id = ${order_id}
     `;
     if (order.length === 0) {

--- a/supabase/migrations/20250901050000_referral_chain.sql
+++ b/supabase/migrations/20250901050000_referral_chain.sql
@@ -1,0 +1,103 @@
+-- Add referral chain support
+
+-- Ensure required extension for HTTP requests
+create extension if not exists "pg_net";
+
+-- Update profiles table for referral chain
+alter table public.profiles
+  add column if not exists referrer_id uuid,
+  add column if not exists seed_code text,
+  add column if not exists seed_activated_at timestamptz;
+
+-- Configure foreign key and uniqueness
+alter table public.profiles
+  drop constraint if exists profiles_referrer_id_fkey;
+alter table public.profiles
+  add constraint profiles_referrer_id_fkey foreign key (referrer_id)
+    references public.profiles(id) on delete set null;
+
+create unique index if not exists profiles_seed_code_idx on public.profiles (seed_code);
+create index if not exists profiles_referrer_id_idx on public.profiles (referrer_id);
+
+alter table public.profiles
+  add constraint if not exists profiles_referrer_self_chk
+    check (referrer_id is null or referrer_id <> id);
+
+-- Row level security: allow users to update their row but not referrer_id
+drop policy if exists "profiles_update" on public.profiles;
+create policy "profiles_update" on public.profiles
+  for update
+  using (
+    auth.uid() = id or current_setting('request.jwt.claim.role', true) = 'admin'
+  )
+  with check (
+    (auth.uid() = id and referrer_id is not distinct from (select referrer_id from public.profiles where id = auth.uid()))
+    or current_setting('request.jwt.claim.role', true) = 'admin'
+  );
+
+-- RPC to activate seed
+create or replace function public.rpc_activate_seed()
+returns text as $$
+declare
+  code text;
+begin
+  code := encode(gen_random_bytes(6), 'hex');
+  update public.profiles
+    set seed_code = code,
+        seed_activated_at = now()
+    where id = auth.uid()
+    returning seed_code into code;
+  return code;
+end;
+$$ language plpgsql security definer;
+
+grant execute on function public.rpc_activate_seed() to authenticated;
+
+-- RPC to set referrer by seed code with cycle check up to 3 levels
+create or replace function public.rpc_set_referrer(seed_code text)
+returns uuid as $$
+declare
+  ref_id uuid;
+  cur uuid;
+  i int;
+begin
+  select id into ref_id from public.profiles where seed_code = rpc_set_referrer.seed_code;
+  if ref_id is null then
+    raise exception 'Invalid seed code';
+  end if;
+
+  cur := ref_id;
+  for i in 1..3 loop
+    exit when cur is null;
+    if cur = auth.uid() then
+      raise exception 'Referral cycle detected';
+    end if;
+    select referrer_id into cur from public.profiles where id = cur;
+  end loop;
+
+  update public.profiles set referrer_id = ref_id where id = auth.uid();
+  return ref_id;
+end;
+$$ language plpgsql security definer;
+
+grant execute on function public.rpc_set_referrer(text) to authenticated;
+
+drop function if exists public.activate_seed(text, uuid);
+
+-- Trigger to invoke compute_commissions edge function after order insert
+create or replace function public.trigger_compute_commissions()
+returns trigger as $$
+begin
+  perform net.http_post(
+    'http://localhost:54321/functions/v1/compute_commissions',
+    '{}'::jsonb,
+    jsonb_build_object('order_id', new.id)::text
+  );
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger orders_compute_commissions
+  after insert on public.orders
+  for each row
+  execute function public.trigger_compute_commissions();

--- a/web/src/pages/Client.tsx
+++ b/web/src/pages/Client.tsx
@@ -14,9 +14,33 @@ export default function Client() {
   const [page, setPage] = useState(1);
   const { data } = useSearchProducts({ ...search, page });
   const add = useCartStore((s) => s.add);
+  const [seedCode, setSeedCode] = useState<string | null>(null);
+
+  const activateSeed = async () => {
+    const baseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+    const res = await fetch(`${baseUrl}/rest/v1/rpc/rpc_activate_seed`, {
+      method: 'POST',
+      headers: {
+        apikey: import.meta.env.VITE_SUPABASE_ANON_KEY as string,
+        Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    if (res.ok) {
+      const code = await res.json();
+      setSeedCode(code as string);
+    }
+  };
 
   return (
     <div className="space-y-4">
+      <div>
+        {seedCode ? (
+          <div>Your seed code: {seedCode}</div>
+        ) : (
+          <button onClick={activateSeed}>Devenir Seed</button>
+        )}
+      </div>
       <SearchBarDual
         onSearch={(value) => {
           setSearch(value);


### PR DESCRIPTION
## Summary
- add referral chain support with new seed activation/referrer RPCs and commissions trigger
- compute commissions starting from order user referrals
- allow clients to activate seeds from the UI and test referral commissions

## Testing
- `npm --prefix web run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ff126364832ba871415660fc0891