### PR TITLE
feat: expand product search rpc

### DIFF
--- a/supabase/migrations/20250809010000_rpc_search_products.sql
+++ b/supabase/migrations/20250809010000_rpc_search_products.sql
@@ -1,11 +1,11 @@
-create or replace function public.search_products(
-  query_name_brand text default '',
-  query_notes text default '',
-  gender text default null,
-  season text default null,
-  family text default null,
-  page int default 1,
-  per_page int default 20
+create or replace function public.rpc_search_products(
+  q_brand_name text,
+  q_ingredients text,
+  gender text,
+  season text,
+  family text,
+  page int,
+  page_size int
 )
 returns setof public.products
 language sql
@@ -15,31 +15,33 @@ as $$
   from public.products
   where active
     and (
-      query_name_brand = '' or
+      q_brand_name is null or q_brand_name = '' or
       to_tsvector('simple', coalesce(inspired_name,'') || ' ' || coalesce(inspired_brand,''))
-        @@ plainto_tsquery('simple', query_name_brand)
+        @@ plainto_tsquery('simple', q_brand_name)
     )
     and (
-      query_notes = '' or
+      q_ingredients is null or q_ingredients = '' or
       to_tsvector('simple',
         coalesce(array_to_string(top_notes,' '), '') || ' ' ||
         coalesce(array_to_string(heart_notes,' '), '') || ' ' ||
         coalesce(array_to_string(base_notes,' '), '') || ' ' ||
         coalesce(olfactory_family,'')
-      ) @@ plainto_tsquery('simple', query_notes)
+      ) @@ plainto_tsquery('simple', q_ingredients)
     )
     and (gender is null or gender = '' or public.products.gender = gender)
     and (season is null or season = '' or public.products.season = season)
     and (family is null or family = '' or public.products.olfactory_family = family)
   order by id
-  limit per_page offset (page - 1) * per_page;
+  limit page_size offset (page - 1) * page_size;
 $$;
 
--- Combined GIN index for search
-create index if not exists products_search_idx on public.products using gin (
+-- Separate GIN indexes for brand/name and ingredients
+create index if not exists products_brand_name_idx on public.products using gin (
+  to_tsvector('simple', coalesce(inspired_name,'') || ' ' || coalesce(inspired_brand,''))
+);
+
+create index if not exists products_ingredients_idx on public.products using gin (
   to_tsvector('simple',
-    coalesce(inspired_name,'') || ' ' ||
-    coalesce(inspired_brand,'') || ' ' ||
     coalesce(array_to_string(top_notes,' '), '') || ' ' ||
     coalesce(array_to_string(heart_notes,' '), '') || ' ' ||
     coalesce(array_to_string(base_notes,' '), '') || ' ' ||

--- a/tests/search_products.test.js
+++ b/tests/search_products.test.js
@@ -40,16 +40,16 @@ const products = [
 ];
 
 function searchLocal({
-  query_name_brand = '',
-  query_notes = '',
+  q_brand_name = '',
+  q_ingredients = '',
   gender,
   season,
   family,
   page = 1,
-  per_page = 20,
+  page_size = 20,
 }) {
-  const qb = query_name_brand.toLowerCase();
-  const qn = query_notes.toLowerCase();
+  const qb = q_brand_name.toLowerCase();
+  const qi = q_ingredients.toLowerCase();
   return products
     .filter((p) => p.active)
     .filter((p) => {
@@ -58,23 +58,25 @@ function searchLocal({
     })
     .filter((p) => {
       const notes = `${p.top_notes.join(' ')} ${p.heart_notes.join(' ')} ${p.base_notes.join(' ')} ${p.olfactory_family}`.toLowerCase();
-      return !qn || notes.includes(qn);
+      return !qi || notes.includes(qi);
     })
     .filter((p) => !gender || p.gender === gender)
     .filter((p) => !season || p.season === season)
     .filter((p) => !family || p.olfactory_family === family)
-    .slice((page - 1) * per_page, page * per_page);
+    .slice((page - 1) * page_size, page * page_size);
 }
-
-const res1 = searchLocal({ query_name_brand: 'woody', query_notes: 'vanilla', page: 1, per_page: 20 });
+const res1 = searchLocal({ q_brand_name: 'woody', q_ingredients: 'vanilla', page: 1, page_size: 20 });
 assert.strictEqual(res1.length, 1);
 assert.strictEqual(res1[0].id, 3);
 
-const res2 = searchLocal({ query_name_brand: 'citrus', page: 1, per_page: 20 });
+const res2 = searchLocal({ q_brand_name: 'citrus', gender: 'unisex', page: 1, page_size: 20 });
 assert.strictEqual(res2[0].id, 2);
 
-const pag1 = searchLocal({ page: 1, per_page: 2 });
-const pag2 = searchLocal({ page: 2, per_page: 2 });
+const res3 = searchLocal({ q_ingredients: 'rose', season: 'spring', family: 'floral', page: 1, page_size: 20 });
+assert.strictEqual(res3[0].id, 1);
+
+const pag1 = searchLocal({ page: 1, page_size: 2 });
+const pag2 = searchLocal({ page: 2, page_size: 2 });
 assert.deepStrictEqual(pag1.map((p) => p.id), [1, 2]);
 assert.deepStrictEqual(pag2.map((p) => p.id), [3]);
 

--- a/web/src/components/SearchBarDual.tsx
+++ b/web/src/components/SearchBarDual.tsx
@@ -1,32 +1,32 @@
 import { useEffect, useState } from 'react';
 
 interface Props {
-  onSearch: (params: { query_name_brand: string; query_notes: string }) => void;
+  onSearch: (params: { q_brand_name: string; q_ingredients: string }) => void;
 }
 
 export default function SearchBarDual({ onSearch }: Props) {
-  const [nameBrand, setNameBrand] = useState('');
-  const [notes, setNotes] = useState('');
+  const [brandName, setBrandName] = useState('');
+  const [ingredients, setIngredients] = useState('');
 
   useEffect(() => {
-    onSearch({ query_name_brand: nameBrand, query_notes: notes });
-  }, [nameBrand, notes, onSearch]);
+    onSearch({ q_brand_name: brandName, q_ingredients: ingredients });
+  }, [brandName, ingredients, onSearch]);
 
   return (
     <div className="flex flex-col gap-2">
       <input
         type="text"
-        placeholder="Nom ou marque"
+        placeholder="Marque ou nom"
         className="w-full p-2 border rounded"
-        value={nameBrand}
-        onChange={(e) => setNameBrand(e.target.value)}
+        value={brandName}
+        onChange={(e) => setBrandName(e.target.value)}
       />
       <input
         type="text"
-        placeholder="Notes ou famille"
+        placeholder="Ingrédients"
         className="w-full p-2 border rounded"
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
+        value={ingredients}
+        onChange={(e) => setIngredients(e.target.value)}
       />
     </div>
   );

--- a/web/src/pages/AdvisorCatalog.tsx
+++ b/web/src/pages/AdvisorCatalog.tsx
@@ -8,10 +8,10 @@ import type { ProductVariant } from '@/types/product';
 
 export default function AdvisorCatalog() {
   const [search, setSearch] = useState({
-    query_name_brand: '',
-    query_notes: '',
+    q_brand_name: '',
+    q_ingredients: '',
   });
-  const { data } = useSearchProducts({ ...search, page: 1 });
+  const { data } = useSearchProducts({ ...search, page: 1, page_size: 20 });
   const add = useCartStore((s) => s.add);
   const [favorites, setFavorites] = useState<number[]>(() => {
     try {
@@ -42,7 +42,7 @@ export default function AdvisorCatalog() {
 
   return (
     <div>
-      <SearchBarDual onSearch={setSearch} />
+      <SearchBarDual onSearch={(params) => setSearch(params)} />
       <div className="mt-4 grid gap-4">
         {data?.map((p) => (
           <div key={p.id} className="border p-2 rounded bg-background text-foreground">

--- a/web/src/pages/Client.tsx
+++ b/web/src/pages/Client.tsx
@@ -8,11 +8,18 @@ import type { ProductVariant } from '@/types/product';
 
 export default function Client() {
   const [search, setSearch] = useState({
-    query_name_brand: '',
-    query_notes: '',
+    q_brand_name: '',
+    q_ingredients: '',
   });
+  const [filters, setFilters] = useState({ gender: '', season: '', family: '' });
   const [page, setPage] = useState(1);
-  const { data } = useSearchProducts({ ...search, page });
+  const pageSize = 20;
+  const { data } = useSearchProducts({
+    ...search,
+    ...filters,
+    page,
+    page_size: pageSize,
+  });
   const add = useCartStore((s) => s.add);
   const [seedCode, setSeedCode] = useState<string | null>(null);
 
@@ -47,6 +54,45 @@ export default function Client() {
           setPage(1);
         }}
       />
+      <div className="flex gap-2">
+        <select
+          value={filters.gender}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, gender: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">Genre</option>
+          <option value="male">Homme</option>
+          <option value="female">Femme</option>
+          <option value="unisex">Unisexe</option>
+        </select>
+        <select
+          value={filters.season}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, season: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">Saison</option>
+          <option value="spring">Printemps</option>
+          <option value="summer">Été</option>
+          <option value="fall">Automne</option>
+          <option value="winter">Hiver</option>
+        </select>
+        <select
+          value={filters.family}
+          onChange={(e) => {
+            setFilters((f) => ({ ...f, family: e.target.value }));
+            setPage(1);
+          }}
+        >
+          <option value="">Famille</option>
+          <option value="floral">Floral</option>
+          <option value="citrus">Citrus</option>
+          <option value="woody">Boisé</option>
+        </select>
+      </div>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {data?.map((p) => (
           <ProductCard
@@ -67,13 +113,13 @@ export default function Client() {
           />
         ))}
       </div>
-      {(search.query_name_brand || search.query_notes) && (
+      {(search.q_brand_name || search.q_ingredients || filters.gender || filters.season || filters.family) && (
         <div className="flex items-center gap-2">
           <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
             Prev
           </button>
           <span>{page}</span>
-          <button onClick={() => setPage((p) => p + 1)} disabled={!data || data.length < 20}>
+          <button onClick={() => setPage((p) => p + 1)} disabled={!data || data.length < pageSize}>
             Next
           </button>
         </div>

--- a/web/src/services/products.ts
+++ b/web/src/services/products.ts
@@ -10,12 +10,13 @@ export interface Product {
 }
 
 export interface SearchParams {
-  query_name_brand: string;
-  query_notes: string;
+  q_brand_name: string;
+  q_ingredients: string;
   gender?: string;
   season?: string;
   family?: string;
   page: number;
+  page_size: number;
 }
 
 function fromApiVariant(row: any): ProductVariant {
@@ -41,7 +42,7 @@ export function toApiVariant(variant: ProductVariant) {
 }
 
 async function searchProducts(params: SearchParams) {
-  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/rpc/search_products`;
+  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/rpc/rpc_search_products`;
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -49,7 +50,7 @@ async function searchProducts(params: SearchParams) {
       apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
       Authorization: `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
     },
-    body: JSON.stringify({ ...params, per_page: 20 }),
+    body: JSON.stringify(params),
   });
   if (!res.ok) {
     throw new Error(await res.text());
@@ -84,17 +85,18 @@ export function useSearchProducts(params: SearchParams) {
   return useQuery({
     queryKey: [
       'products',
-      params.query_name_brand,
-      params.query_notes,
+      params.q_brand_name,
+      params.q_ingredients,
       params.gender,
       params.season,
       params.family,
       params.page,
+      params.page_size,
     ],
     queryFn: () => searchProducts(params),
     enabled:
-      params.query_name_brand.length > 0 ||
-      params.query_notes.length > 0 ||
+      params.q_brand_name.length > 0 ||
+      params.q_ingredients.length > 0 ||
       !!params.gender ||
       !!params.season ||
       !!params.family,


### PR DESCRIPTION
## Summary
- rename search_products to rpc_search_products and support brand/ingredient filters with pagination
- forward new query parameters through services and update search bar + client UI
- extend search tests for filter combinations and page sizing

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980bf8b4cc832bbb7ca9dec77bbdcb