### PR TITLE
Refactor variant stock tracking

### DIFF
--- a/supabase/migrations/20250901070000_variant_stocks_refactor.sql
+++ b/supabase/migrations/20250901070000_variant_stocks_refactor.sql
@@ -1,0 +1,33 @@
+-- Move stock quantities to dedicated table
+
+-- Rename columns in variant_stocks table
+alter table public.variant_stocks
+  rename column product_variant_id to variant_id;
+
+alter table public.variant_stocks
+  rename column qty to stock_current;
+
+alter table public.variant_stocks
+  add column stock_min integer not null default 0;
+
+alter table public.variant_stocks
+  add column created_at timestamptz not null default now();
+
+alter table public.variant_stocks
+  alter column updated_at set default now();
+
+-- Migrate existing stock data from product_variants
+insert into public.variant_stocks (variant_id, stock_current, stock_min)
+select id, stock_qty, stock_min from public.product_variants
+on conflict (variant_id) do update
+  set stock_current = excluded.stock_current,
+      stock_min = excluded.stock_min,
+      updated_at = now();
+
+-- Remove stock columns from product_variants
+alter table public.product_variants drop column stock_qty;
+alter table public.product_variants drop column stock_min;
+
+-- Rename foreign key columns for consistency
+alter table public.stock_adjustments
+  rename column product_variant_id to variant_id;

--- a/supabase/seeds/seed.sql
+++ b/supabase/seeds/seed.sql
@@ -14,29 +14,57 @@ values
   ('P003', 'Woody Night', 'BrandC', 'male', 'winter', 'woody', '{cedar}', '{patchouli}', '{vanilla}', 'Warm woody aroma', '', true);
 
 -- Variants
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P001-15', id, 15, 20, 10, 50, 5 from products where product_code = 'P001';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P001-30', id, 30, 35, 18, 40, 5 from products where product_code = 'P001';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P001-50', id, 50, 50, 25, 30, 5 from products where product_code = 'P001';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P001-100', id, 100, 90, 45, 20, 5 from products where product_code = 'P001';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P001-15', id, 15, 20, 10 from products where product_code = 'P001';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P001-30', id, 30, 35, 18 from products where product_code = 'P001';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P001-50', id, 50, 50, 25 from products where product_code = 'P001';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P001-100', id, 100, 90, 45 from products where product_code = 'P001';
 
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P002-15', id, 15, 18, 9, 60, 5 from products where product_code = 'P002';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P002-30', id, 30, 32, 16, 50, 5 from products where product_code = 'P002';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P002-50', id, 50, 45, 22, 40, 5 from products where product_code = 'P002';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P002-100', id, 100, 80, 40, 30, 5 from products where product_code = 'P002';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P002-15', id, 15, 18, 9 from products where product_code = 'P002';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P002-30', id, 30, 32, 16 from products where product_code = 'P002';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P002-50', id, 50, 45, 22 from products where product_code = 'P002';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P002-100', id, 100, 80, 40 from products where product_code = 'P002';
 
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P003-15', id, 15, 22, 11, 50, 5 from products where product_code = 'P003';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P003-30', id, 30, 38, 19, 40, 5 from products where product_code = 'P003';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P003-50', id, 50, 55, 27, 30, 5 from products where product_code = 'P003';
-insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd, stock_qty, stock_min)
-select 'P003-100', id, 100, 95, 47, 20, 5 from products where product_code = 'P003';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P003-15', id, 15, 22, 11 from products where product_code = 'P003';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P003-30', id, 30, 38, 19 from products where product_code = 'P003';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P003-50', id, 50, 55, 27 from products where product_code = 'P003';
+insert into product_variants (variant_code, product_id, volume_ml, price_tnd, cost_tnd)
+select 'P003-100', id, 100, 95, 47 from products where product_code = 'P003';
+
+-- Variant stocks
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 50, 5 from product_variants where variant_code = 'P001-15';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 40, 5 from product_variants where variant_code = 'P001-30';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 30, 5 from product_variants where variant_code = 'P001-50';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 20, 5 from product_variants where variant_code = 'P001-100';
+
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 60, 5 from product_variants where variant_code = 'P002-15';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 50, 5 from product_variants where variant_code = 'P002-30';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 40, 5 from product_variants where variant_code = 'P002-50';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 30, 5 from product_variants where variant_code = 'P002-100';
+
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 50, 5 from product_variants where variant_code = 'P003-15';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 40, 5 from product_variants where variant_code = 'P003-30';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 30, 5 from product_variants where variant_code = 'P003-50';
+insert into variant_stocks (variant_id, stock_current, stock_min)
+select id, 20, 5 from product_variants where variant_code = 'P003-100';

--- a/web/src/pages/AdminStocks.tsx
+++ b/web/src/pages/AdminStocks.tsx
@@ -5,9 +5,9 @@ export default function AdminStocks() {
   const { data: variants, refetch } = useProductVariants();
   const [loading, setLoading] = useState(false);
 
-  const ruptures = variants?.filter(v => v.stockQty === 0) ?? [];
-  const low = variants?.filter(v => v.stockQty > 0 && v.stockQty < v.stockMin) ?? [];
-  const ok = variants?.filter(v => v.stockQty >= v.stockMin) ?? [];
+  const ruptures = variants?.filter(v => v.stockCurrent === 0) ?? [];
+  const low = variants?.filter(v => v.stockCurrent > 0 && v.stockCurrent < v.stockMin) ?? [];
+  const ok = variants?.filter(v => v.stockCurrent >= v.stockMin) ?? [];
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -31,7 +31,7 @@ export default function AdminStocks() {
         <ul className="mt-2 flex flex-col gap-1">
           {list.map(v => (
             <li key={v.id}>
-              {v.products.inspiredName} {v.size_ml}ml ({v.stockQty})
+              {v.products.inspiredName} {v.size_ml}ml ({v.stockCurrent})
             </li>
           ))}
         </ul>

--- a/web/src/services/stock.ts
+++ b/web/src/services/stock.ts
@@ -3,7 +3,7 @@ import type { ProductVariant } from '@/types/product';
 
 export interface StockVariant extends ProductVariant {
   variantCode: string;
-  stockQty: number;
+  stockCurrent: number;
   stockMin: number;
   products: { inspiredName: string };
 }
@@ -23,15 +23,15 @@ function fromApiStockVariant(row: any): StockVariant {
     discount_tnd: row.discount_tnd ?? undefined,
     name: row.name ?? undefined,
     variantCode: row.variant_code,
-    stockQty: row.stock_qty,
-    stockMin: row.stock_min,
+    stockCurrent: row.variant_stocks?.stock_current ?? 0,
+    stockMin: row.variant_stocks?.stock_min ?? 0,
     products: { inspiredName: row.products?.inspired_name },
   };
 }
 
 async function fetchVariants(): Promise<StockVariant[]> {
   const res = await fetch(
-    `${baseUrl}/rest/v1/product_variants?select=*,products(inspired_name)`,
+    `${baseUrl}/rest/v1/product_variants?select=*,products(inspired_name),variant_stocks(stock_current,stock_min)`,
     { headers }
   );
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- migrate stock quantities from `product_variants` into a dedicated `variant_stocks` table with `stock_current` and `stock_min`
- adjust stock import function and front-end to read/write stock from the new table
- seed variant stock data separately from product variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d184718c832ba0497142dba40e03