### PR TITLE
Validate promotion conditions and expand promotion tests

### DIFF
--- a/edge-functions/apply_promotions/index.ts
+++ b/edge-functions/apply_promotions/index.ts
@@ -16,20 +16,60 @@ const bodySchema = z.object({
 
 type Item = z.infer<typeof itemSchema> & { discount_tnd: number };
 
+const discountConditionSchema = z.object({
+  product_variant_id: z.number().int(),
+  percent: z.number().nonnegative(),
+});
+
+const twoPlusOneConditionSchema = z.union([
+  z.object({ product_variant_id: z.number().int() }),
+  z.object({
+    product_variant_ids: z.array(z.number().int()).min(1),
+    price_diff_tnd: z.number().nonnegative().optional(),
+  }),
+]);
+
+const packConditionSchema = z.object({
+  product_variant_ids: z.array(z.number().int()).min(1),
+  price: z.number().nonnegative(),
+});
+
+type DiscountCondition = z.infer<typeof discountConditionSchema>;
+type TwoPlusOneCondition = z.infer<typeof twoPlusOneConditionSchema>;
+type PackCondition = z.infer<typeof packConditionSchema>;
+
 serve(async (req) => {
   try {
     const { items } = bodySchema.parse(await req.json());
     const result: Item[] = items.map((i) => ({ ...i, discount_tnd: 0 }));
 
-    const promotions = await sql`
+    const rawPromotions = await sql`
       select type, condition_json
       from promotions
       where active = true and now() between starts_at and ends_at
     `;
 
-    for (const p of promotions.filter((p: any) => p.type === 'pack')) {
-      const ids: number[] = p.condition_json.product_variant_ids || [];
-      const price: number = p.condition_json.price;
+    const promotions = rawPromotions.map((p: any) => {
+      switch (p.type) {
+        case 'pack':
+          return { type: 'pack', condition: packConditionSchema.parse(p.condition_json) } as const;
+        case 'two_plus_one':
+          return { type: 'two_plus_one', condition: twoPlusOneConditionSchema.parse(p.condition_json) } as const;
+        case 'discount':
+          return { type: 'discount', condition: discountConditionSchema.parse(p.condition_json) } as const;
+        default:
+          return null;
+      }
+    }).filter((p: any): p is Promotion => Boolean(p));
+
+    type Promotion =
+      | { type: 'pack'; condition: PackCondition }
+      | { type: 'two_plus_one'; condition: TwoPlusOneCondition }
+      | { type: 'discount'; condition: DiscountCondition };
+
+    for (const p of promotions.filter((p) => p.type === 'pack')) {
+      const ids = p.condition.product_variant_ids || [];
+      const price = p.condition.price;
       const matches = ids.map((id) =>
         result.find((r) => r.product_variant_id === id)
       );
@@ -44,19 +84,40 @@ serve(async (req) => {
       });
     }
 
-    for (const p of promotions.filter((p: any) => p.type === 'two_plus_one')) {
-      const id = p.condition_json.product_variant_id;
-      const item = result.find((r) => r.product_variant_id === id);
-      if (!item) continue;
-      const freeCount = Math.floor(item.qty / 3);
-      if (freeCount <= 0) continue;
-      const totalDiscount = freeCount * item.unit_price_tnd;
-      item.discount_tnd += totalDiscount / item.qty;
+    for (const p of promotions.filter((p) => p.type === 'two_plus_one')) {
+      const c = p.condition;
+      if ('product_variant_id' in c) {
+        const item = result.find((r) => r.product_variant_id === c.product_variant_id);
+        if (!item) continue;
+        const freeCount = Math.floor(item.qty / 3);
+        if (freeCount <= 0) continue;
+        const totalDiscount = freeCount * item.unit_price_tnd;
+        item.discount_tnd += totalDiscount / item.qty;
+      } else {
+        const ids = c.product_variant_ids || [];
+        const maxDiff = c.price_diff_tnd ?? 0;
+        const units: Item[] = [];
+        for (const item of result.filter((r) => ids.includes(r.product_variant_id))) {
+          for (let i = 0; i < item.qty; i++) units.push(item);
+        }
+        units.sort((a, b) => b.unit_price_tnd - a.unit_price_tnd);
+        while (units.length >= 3) {
+          const group = units.slice(0, 3);
+          const diff = group[0].unit_price_tnd - group[2].unit_price_tnd;
+          if (diff <= maxDiff) {
+            const cheapest = group[2];
+            cheapest.discount_tnd += cheapest.unit_price_tnd / cheapest.qty;
+            units.splice(0, 3);
+          } else {
+            units.shift();
+          }
+        }
+      }
     }
 
-    for (const p of promotions.filter((p: any) => p.type === 'discount')) {
-      const id = p.condition_json.product_variant_id;
-      const percent = p.condition_json.percent;
+    for (const p of promotions.filter((p) => p.type === 'discount')) {
+      const id = p.condition.product_variant_id;
+      const percent = p.condition.percent;
       const item = result.find((r) => r.product_variant_id === id);
       if (!item) continue;
       item.discount_tnd += item.unit_price_tnd * (percent / 100);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "lollyspace-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js"
+    "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js"
   }
 }

--- a/tests/apply_promotions.test.js
+++ b/tests/apply_promotions.test.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+
+function applyPromotions(items, promotions) {
+  const result = items.map((i) => ({ ...i, discount_tnd: 0 }));
+
+  for (const p of promotions.filter((p) => p.type === 'pack')) {
+    const ids = p.condition.product_variant_ids || [];
+    const price = p.condition.price;
+    const matches = ids.map((id) => result.find((r) => r.product_variant_id === id));
+    if (matches.some((m) => !m)) continue;
+    const packCount = Math.min(...matches.map((m) => m.qty));
+    if (packCount <= 0) continue;
+    const sumPrice = matches.reduce((s, m) => s + m.unit_price_tnd, 0);
+    const discountPerPack = sumPrice - price;
+    const discountPerItem = discountPerPack / ids.length;
+    matches.forEach((m) => {
+      m.discount_tnd += (discountPerItem * packCount) / m.qty;
+    });
+  }
+
+  for (const p of promotions.filter((p) => p.type === 'two_plus_one')) {
+    const c = p.condition;
+    if (c.product_variant_id) {
+      const item = result.find((r) => r.product_variant_id === c.product_variant_id);
+      if (!item) continue;
+      const freeCount = Math.floor(item.qty / 3);
+      if (freeCount <= 0) continue;
+      const totalDiscount = freeCount * item.unit_price_tnd;
+      item.discount_tnd += totalDiscount / item.qty;
+    } else {
+      const ids = c.product_variant_ids || [];
+      const maxDiff = c.price_diff_tnd ?? 0;
+      const units = [];
+      for (const item of result.filter((r) => ids.includes(r.product_variant_id))) {
+        for (let i = 0; i < item.qty; i++) units.push(item);
+      }
+      units.sort((a, b) => b.unit_price_tnd - a.unit_price_tnd);
+      while (units.length >= 3) {
+        const group = units.slice(0, 3);
+        const diff = group[0].unit_price_tnd - group[2].unit_price_tnd;
+        if (diff <= maxDiff) {
+          const cheapest = group[2];
+          cheapest.discount_tnd += cheapest.unit_price_tnd / cheapest.qty;
+          units.splice(0, 3);
+        } else {
+          units.shift();
+        }
+      }
+    }
+  }
+
+  for (const p of promotions.filter((p) => p.type === 'discount')) {
+    const id = p.condition.product_variant_id;
+    const percent = p.condition.percent;
+    const item = result.find((r) => r.product_variant_id === id);
+    if (!item) continue;
+    item.discount_tnd += item.unit_price_tnd * (percent / 100);
+  }
+
+  return result;
+}
+
+// Overlapping promotions: discount + two_plus_one
+(() => {
+  const items = [{ product_variant_id: 1, qty: 3, unit_price_tnd: 10 }];
+  const promotions = [
+    { type: 'discount', condition: { product_variant_id: 1, percent: 10 } },
+    { type: 'two_plus_one', condition: { product_variant_id: 1 } },
+  ];
+  const res = applyPromotions(items, promotions);
+  const totalDiscount = res[0].discount_tnd * res[0].qty;
+  assert(Math.abs(totalDiscount - 13) < 1e-6);
+})();
+
+// Two_plus_one across equal prices
+(() => {
+  const items = [
+    { product_variant_id: 1, qty: 1, unit_price_tnd: 10 },
+    { product_variant_id: 2, qty: 2, unit_price_tnd: 10 },
+  ];
+  const promotions = [
+    { type: 'two_plus_one', condition: { product_variant_ids: [1, 2] } },
+  ];
+  const res = applyPromotions(items, promotions);
+  const totalDiscount = res.reduce((s, i) => s + i.discount_tnd * i.qty, 0);
+  assert.strictEqual(totalDiscount, 10);
+})();
+
+// Two_plus_one with price difference allowance
+(() => {
+  const items = [
+    { product_variant_id: 1, qty: 1, unit_price_tnd: 10 },
+    { product_variant_id: 2, qty: 1, unit_price_tnd: 9 },
+    { product_variant_id: 3, qty: 1, unit_price_tnd: 10 },
+  ];
+  const promotions = [
+    {
+      type: 'two_plus_one',
+      condition: { product_variant_ids: [1, 2, 3], price_diff_tnd: 1 },
+    },
+  ];
+  const res = applyPromotions(items, promotions);
+  const item2 = res.find((i) => i.product_variant_id === 2);
+  assert.strictEqual(item2.discount_tnd, 9);
+})();
+
+console.log('apply_promotions tests passed');


### PR DESCRIPTION
## Summary
- validate promotion condition_json with Zod schemas per type
- support two_plus_one promotions based on equal price or price difference
- test overlapping promotions and price-based 2+1 scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d4296620832bb402fca22d097569