### PR TITLE
feat: paginate stock state

### DIFF
--- a/supabase/migrations/20250901080000_rpc_get_stock_state.sql
+++ b/supabase/migrations/20250901080000_rpc_get_stock_state.sql
@@ -1,0 +1,62 @@
+create or replace function public.rpc_get_stock_state(
+  page int,
+  size int,
+  filters jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+stable
+as $$
+declare
+  result jsonb;
+begin
+  result := jsonb_build_object(
+    'rows', (
+      select coalesce(jsonb_agg(row_to_json(t)), '[]'::jsonb) from (
+        select
+          pv.id,
+          pv.product_id,
+          pv.volume_ml,
+          pv.price_tnd,
+          pv.discount_tnd,
+          pv.name,
+          pv.variant_code,
+          jsonb_build_object(
+            'stock_current', coalesce(vs.stock_current, 0),
+            'stock_min', coalesce(vs.stock_min, 0)
+          ) as variant_stocks,
+          jsonb_build_object(
+            'inspired_name', p.inspired_name
+          ) as products
+        from public.product_variants pv
+        join public.products p on p.id = pv.product_id
+        left join public.variant_stocks vs on vs.variant_id = pv.id
+        order by pv.id
+        limit size offset greatest(page - 1, 0) * size
+      ) t
+    ),
+    'counts', jsonb_build_object(
+      'ruptures', (
+        select count(*)
+        from public.product_variants pv
+        left join public.variant_stocks vs on vs.variant_id = pv.id
+        where coalesce(vs.stock_current, 0) = 0
+      ),
+      'low', (
+        select count(*)
+        from public.product_variants pv
+        left join public.variant_stocks vs on vs.variant_id = pv.id
+        where coalesce(vs.stock_current, 0) > 0
+          and coalesce(vs.stock_current, 0) < coalesce(vs.stock_min, 0)
+      ),
+      'ok', (
+        select count(*)
+        from public.product_variants pv
+        left join public.variant_stocks vs on vs.variant_id = pv.id
+        where coalesce(vs.stock_current, 0) >= coalesce(vs.stock_min, 0)
+      )
+    )
+  );
+  return result;
+end;
+$$;

--- a/web/src/pages/AdminStocks.tsx
+++ b/web/src/pages/AdminStocks.tsx
@@ -2,12 +2,15 @@ import { useProductVariants, importStock, StockVariant } from '../services/stock
 import { useState } from 'react';
 
 export default function AdminStocks() {
-  const { data: variants, refetch } = useProductVariants();
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+  const { data, refetch } = useProductVariants(page, pageSize);
+  const variants = data?.rows ?? [];
   const [loading, setLoading] = useState(false);
 
-  const ruptures = variants?.filter(v => v.stockCurrent === 0) ?? [];
-  const low = variants?.filter(v => v.stockCurrent > 0 && v.stockCurrent < v.stockMin) ?? [];
-  const ok = variants?.filter(v => v.stockCurrent >= v.stockMin) ?? [];
+  const ruptures = variants.filter(v => v.stockCurrent === 0);
+  const low = variants.filter(v => v.stockCurrent > 0 && v.stockCurrent < v.stockMin);
+  const ok = variants.filter(v => v.stockCurrent >= v.stockMin);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -67,6 +70,16 @@ export default function AdminStocks() {
       {renderList('Ruptures', ruptures)}
       {renderList('Stock minimum', low)}
       {renderList('OK', ok)}
+
+      <div className="mt-4 flex items-center gap-2">
+        <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
+          Prev
+        </button>
+        <span>{page}</span>
+        <button onClick={() => setPage(p => p + 1)} disabled={variants.length < pageSize}>
+          Next
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add rpc_get_stock_state to return paginated stock data with counts
- query stock RPC with paging in React service
- paginate AdminStocks page to load further variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898ec39e060832b87f0587d578b1f90