### PR TITLE
chore: run playwright via npx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,78 @@ jobs:
         run: npm run typecheck --if-present
       - name: Build
         run: npm run build
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      # Forcer le registre npmjs + retries anti-403
+      - name: Configure npm registry + retries
+        run: |
+          npm config set registry "https://registry.npmjs.org/"
+          npm config set @playwright:registry "https://registry.npmjs.org/"
+          npm config set fetch-retries 5
+          npm config set fetch-retry-factor 2
+          npm config set fetch-retry-maxtimeout 60000
+        working-directory: web
+
+      - name: Install deps (app)
+        run: npm ci --no-audit --no-fund
+        working-directory: web
+
+      - name: Build (for preview server)
+        run: npm run build
+        working-directory: web
+
+      # Vérifier l’accessibilité réelle du package @playwright/test (200 attendu)
+      - id: npm-registry
+        name: Check npm registry access (playwright)
+        run: |
+          set -e
+          URL="https://registry.npmjs.org/@playwright%2Ftest"
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+          echo "http_code=$CODE"
+          if [ "$CODE" = "200" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "status=$CODE" >> "$GITHUB_OUTPUT"
+          fi
+        working-directory: web
+
+      # Installer les navigateurs et lancer les tests UNIQUEMENT si le registre est OK
+      - name: Install Playwright browsers
+        if: steps.npm-registry.outputs.ok == 'true'
+        run: npx --yes playwright@1.54.2 install --with-deps
+        working-directory: web
+
+      - name: Run E2E tests
+        if: steps.npm-registry.outputs.ok == 'true'
+        run: npx --yes @playwright/test@1.54.2 test --reporter=line
+        working-directory: web
+
+      # Si le registre est KO (403, etc.), on SKIP proprement (pipeline reste vert)
+      - name: Skip E2E (npm registry blocked)
+        if: steps.npm-registry.outputs.ok != 'true'
+        run: |
+          echo "::warning::Skipping E2E: npm registry returned status ${{ steps.npm-registry.outputs.status || 'unknown' }}."
+          echo "When registry access is restored, E2E will run automatically."
+
+      - name: Upload Playwright report
+        if: always() && steps.npm-registry.outputs.ok == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            web/playwright-report
+            web/test-results
+          retention-days: 7

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,6 @@
+registry=https://registry.npmjs.org/
+@playwright:registry=https://registry.npmjs.org/
+strict-ssl=true
+always-auth=false
+fund=false
+audit=false

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: 'tests/e2e',
+  testMatch: '**/*.spec.ts',
+  timeout: 30_000,
+  use: { baseURL: 'http://localhost:4173', headless: true },
+  webServer: { command: 'npm run preview', port: 4173, reuseExistingServer: !process.env.CI, timeout: 60_000 },
+  reporter: [['line'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+});

--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('home loads', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await expect(page).toHaveTitle(/Compas|Lolly/i);
+});


### PR DESCRIPTION
## Summary
- configure Playwright via standalone config and smoke test
- pin CI end-to-end tests to Playwright 1.54.2 using npx
- force npmjs registry in web/.npmrc
- skip e2e tests when npm registry is unreachable

## Testing
- `npm ci --no-audit --no-fund`
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npx --yes @playwright/test@1.54.2 test --reporter=line` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_6899192e80f4832b921c0e472eee10ac