### PR TITLE
ci: make e2e workflow non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,59 @@ jobs:
         run: npm run typecheck --if-present
       - name: Build
         run: npm run build
+
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install deps (app)
+        run: npm ci --no-audit --no-fund
+        working-directory: web
+
+      - name: Build (for preview server)
+        run: npm run build
+        working-directory: web
+
+      - name: Ensure Playwright is runnable or skip
+        id: pw-check
+        shell: bash
+        run: |
+          npm config set registry "https://registry.npmjs.org/" >/dev/null 2>&1 || true
+          npm config set @playwright:registry "https://registry.npmjs.org/" >/dev/null 2>&1 || true
+          # tenter une résolution rapide ; si ça échoue, on skip
+          node -e "require.resolve('@playwright/test/package.json')" \
+            && echo 'ok=true' >> "$GITHUB_OUTPUT" \
+            || echo 'ok=false' >> "$GITHUB_OUTPUT"
+        working-directory: web
+
+      - name: Install Playwright browsers
+        if: steps.pw-check.outputs.ok == 'true'
+        run: npx --yes playwright@1.54.2 install --with-deps
+        working-directory: web
+
+      - name: Run E2E tests
+        if: steps.pw-check.outputs.ok == 'true'
+        run: npx --yes @playwright/test@1.54.2 test --reporter=line
+        working-directory: web
+
+      - name: Skip E2E (Playwright not available)
+        if: steps.pw-check.outputs.ok != 'true'
+        run: echo "::warning::E2E skipped: Playwright not available on CI runner."
+
+      - name: Upload Playwright report
+        if: always() && steps.pw-check.outputs.ok == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            web/playwright-report
+            web/test-results
+          retention-days: 7


### PR DESCRIPTION
## Summary
- add optional e2e job that checks for Playwright availability and skips when missing
- keep lint/typecheck/build as required steps

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68991da6c2ac832b979332e6e13dab01