### PR TITLE
docs: add Playwright E2E instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ npm run dev
 ## Supabase
 Migrations reside in `supabase/migrations` and seeds in `supabase/seeds`.
 Run `supabase db reset` to apply them locally.
+
+## Playwright E2E
+Run the end-to-end suite from the `web` package:
+```bash
+cd web
+npm run test:e2e
+```
+
+This executes four scenarios:
+1. Admin exports sales and commissions.
+2. Advisor completes a sale and reduces stock.
+3. Client searches for and purchases a product.
+4. Referral purchase generates commissions and an admin pays them.
+
+On failure, screenshots and videos are stored under `web/test-results/` in a folder named for the failing test.


### PR DESCRIPTION
## Summary
- document Playwright E2E suite and scenarios
- note where failed test artifacts are stored

## Testing
- `npm test`
- `cd web && npm run test:e2e` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_68992b042fb4832b9ce9b12b5ad92863