### PR TITLE
test: add smoke E2E for cart badge

### DIFF
--- a/web/tests/e2e/smoke.spec.ts
+++ b/web/tests/e2e/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+// Basic smoke test verifying cart badge increments when adding a product from the home page.
+test('adding first product increments cart badge', async ({ page }) => {
+  try {
+    // Visit home page and record initial cart badge value
+    await page.goto('/');
+    const badge = page.locator('[data-test="cart-badge"]');
+    const initial = parseInt((await badge.textContent()) || '0', 10);
+
+    // Open first product and add to cart
+    await page.locator('[data-test="product-card"]').first().click();
+    await expect(page).toHaveURL(/products\/\d+/);
+    await page.click('[data-test="add-to-cart"]');
+
+    // Ensure cart badge incremented
+    await expect(badge).toHaveText(String(initial + 1));
+  } catch (error) {
+    await page.screenshot({ path: `smoke-failure-${Date.now()}.png`, fullPage: true });
+    throw error;
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright smoke test that adds the first product to cart and checks cart badge

## Testing
- `npm --prefix web run test:e2e -- --headless tests/e2e/smoke.spec.ts` *(fails: 403 Forbidden from registry while fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68992d602fc0832b9cb30bcf85cbcb3c