### PR TITLE
Add Vitest unit tests and CI integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm run lint --if-present
       - name: Typecheck
         run: npm run typecheck --if-present
+      - name: Unit tests
+        run: npm run test:unit
       - name: Build
         run: npm run build
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && vite build",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test:e2e": "npx --yes @playwright/test test --reporter=line"
+    "test:e2e": "npx --yes @playwright/test test --reporter=line",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
@@ -29,6 +30,8 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.1.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.6.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/web/tests/unit/sample.test.ts
+++ b/web/tests/unit/sample.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+function SampleComponent() {
+  return <div>Hello Vitest</div>;
+}
+
+describe('SampleComponent', () => {
+  it('renders greeting', () => {
+    const html = renderToString(<SampleComponent />);
+    expect(html).toContain('Hello Vitest');
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- add Vitest and jsdom dev dependencies with a test:unit script
- configure Vitest in Vite and add a sample component test
- run unit tests in CI workflow

## Testing
- `npm run test:unit` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68992e87f210832bb9ba36d7d1fb18ef