### PR TITLE
chore: add eslint configuration

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2021,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  plugins: ['@typescript-eslint', 'react', 'jsx-a11y', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+  ],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test:e2e": "npx --yes @playwright/test test --reporter=line",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "lint": "eslint src --ext .ts,.tsx"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",
@@ -27,6 +28,12 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
+    "eslint": "^9.32.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.1.0",


### PR DESCRIPTION
## Summary
- add lint script and dev dependencies for ESLint
- configure React and accessibility linting

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npm run test:unit` *(fails: Failed to resolve import "@playwright/test")*

------
https://chatgpt.com/codex/tasks/task_e_68992fe9c54c832ba87501b92446c682