### PR TITLE
docs: add acceptance and uat guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ This executes four scenarios:
 4. Referral purchase generates commissions and an admin pays them.
 
 On failure, screenshots and videos are stored under `web/test-results/` in a folder named for the failing test.
+
+## Documentation
+
+- [Acceptance Testing Guide](docs/acceptance.md)
+- [UAT Checklist v1](docs/uat_v1.md)

--- a/docs/acceptance.md
+++ b/docs/acceptance.md
@@ -2,21 +2,57 @@
 
 This guide explains how to manually verify key user flows before merging changes.
 
-## Stock Imports
+## Re-running Automated Tests
+
+Run the Playwright suite to verify end-to-end flows:
+
+```bash
+cd web
+npm run test:e2e
+```
+
+On failure, screenshots and videos are saved to `web/test-results/` for inspection.
+
+## Client Flow
+
+1. Log in as a client.
+2. Use the search bar to find a product.
+3. Add the item to the cart and proceed to checkout.
+4. Complete payment and confirm an order confirmation message appears.
+5. Verify the order shows in the client's order history.
+
+## Advisor Flow
+
+1. Log in as an advisor.
+2. Start a new sale and select a product.
+3. Complete the sale and confirm stock levels decrease.
+4. Ensure the sale appears under advisor commissions.
+5. Verify the client receives a receipt.
+
+## Admin Flows
+
+### Export Sales and Commissions
+
+1. Log in as an administrator.
+2. Navigate to **Reports → Export**.
+3. Generate the sales and commissions report.
+4. Confirm a CSV file downloads and contains expected data.
+
+### Stock Imports
 1. Log in as an administrator.
 2. Navigate to **Inventory → Stock Import**.
 3. Upload a CSV file with sample products.
 4. Confirm the preview matches the file contents and submit the import.
 5. Verify new inventory entries appear in the product list.
 
-## Promotions
+### Promotions
 1. Log in as an administrator.
 2. Go to **Marketing → Promotions**.
 3. Create a new promotion with a discount code and expiry date.
 4. Apply the code during checkout to confirm the discount is applied.
 5. Ensure the promotion appears in the promotions list and can be toggled on/off.
 
-## Dashboards
+### Dashboards
 1. Sign in to the dashboard as a merchant.
 2. Open **Reports → Sales Dashboard**.
 3. Confirm charts render for total revenue, top products, and recent orders.

--- a/docs/uat_v1.md
+++ b/docs/uat_v1.md
@@ -1,0 +1,14 @@
+# UAT Checklist v1
+
+Use this list to manually verify the main flows before releasing.
+
+1. Search for a product as a client.
+2. Add the product to the cart and complete checkout.
+3. Confirm the order appears in the client's order history.
+4. Log in as an advisor and record a sale.
+5. Verify inventory levels decrease after the advisor sale.
+6. Complete a referral purchase and confirm commissions are generated.
+7. Log in as an administrator and export the sales report.
+8. Import new stock from a CSV file and verify products appear.
+9. Create a promotion and ensure it can be enabled or disabled.
+10. Review the sales dashboard and export metrics to CSV.


### PR DESCRIPTION
## Summary
- expand acceptance testing guide with client, advisor, and admin flows
- add UAT checklist doc
- link new docs from README

## Testing
- `cd web && npm run test:e2e` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_689933c39b24832bb0346cfc3f724db0