### PR TITLE
Add env templates and health check script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_SUPABASE_URL=your-url
+VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SENTRY_DSN=your-sentry-dsn
+VITE_ANALYTICS_KEY=your-analytics-key

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,4 @@
+VITE_SUPABASE_URL=https://staging-url
+VITE_SUPABASE_ANON_KEY=staging-anon-key
+VITE_SENTRY_DSN=staging-sentry-dsn
+VITE_ANALYTICS_KEY=staging-analytics-key

--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ npm install
 cd web && npm install
 ```
 
-Create a `.env` file in `web/` with:
+Copy `.env.example` to `web/.env` and fill in:
 ```
 VITE_SUPABASE_URL=your-url
 VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SENTRY_DSN=your-sentry-dsn
+VITE_ANALYTICS_KEY=your-analytics-key
+```
+
+For staging deployments, start from `.env.staging`:
+```bash
+cp .env.staging web/.env
 ```
 
 ### Development

--- a/env.example
+++ b/env.example
@@ -1,2 +1,0 @@
-VITE_SUPABASE_URL=your-url
-VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview",
     "test:e2e": "npx --yes @playwright/test test --reporter=line",
     "test:unit": "vitest run",
-    "lint": "eslint src --ext .ts,.tsx"
+    "lint": "eslint src --ext .ts,.tsx",
+    "health": "curl -f http://localhost:5173/healthz"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",


### PR DESCRIPTION
## Summary
- rename env.example to .env.example with Supabase, Sentry and analytics placeholders
- add .env.staging template
- document env usage in README
- add `health` script to web package.json

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689934826bdc832ba8b46010b1f81563