### PR TITLE
chore: release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 - 2025-08-11
+
+### Continuous Integration
+- upload smoke test artifacts

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.0.0",
         "react": "^18.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
           <Route path="/admin/commission-rules" element={<AdminCommissionRules />} />
         </Routes>
       </main>
-      <footer className="p-4 text-center text-xs text-neutral-500">{version}</footer>
+      <footer className="p-4 text-center text-xs text-neutral-500">Version {version}</footer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- bump web app to 1.0.0
- add changelog for the final release
- surface version label in footer

## Testing
- `npm --prefix web run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm --prefix web run test:unit` *(fails: vitest: not found)*
- `npm --prefix web run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68993b56f0b0832b9075738c0e0d28ea