### PR TITLE
chore: build dist artifact in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,19 @@ jobs:
         run: npm ci --no-audit --no-fund
       - name: Build
         run: npm run build
-      - name: Archive dist
-        run: tar -czf dist.tar.gz dist
+      - name: Zip dist
+        run: zip -r dist.zip dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: web/dist.zip
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: web/dist.tar.gz
+          draft: true
+          files: web/dist.zip
+          body_path: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- zip the web dist folder and upload it as an artifact
- create a draft GitHub release using CHANGELOG.md as the release body

## Testing
- `npm ci --no-audit --no-fund` *(fails: unable to resolve dependency tree)*
- `npm run build` *(fails: cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68993cb34b08832b8e1820eb9d799030