### PR TITLE
feat(web): write version metadata

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -9,12 +9,14 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "postbuild": "node scripts/write-version-json.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test:e2e": "npx --yes @playwright/test test --reporter=line",
     "test:unit": "vitest run",
     "lint": "eslint src --ext .ts,.tsx",
-    "health": "curl -f http://localhost:5173/healthz"
+    "health": "curl -f http://localhost:5173/healthz",
+    "release:tag": "git tag v$npm_package_version && git push origin v$npm_package_version"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/web/scripts/write-version-json.mjs
+++ b/web/scripts/write-version-json.mjs
@@ -1,0 +1,15 @@
+import { execSync } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import pkg from '../package.json' with { type: 'json' };
+
+const commit = process.env.GITHUB_SHA || execSync('git rev-parse HEAD').toString().trim();
+
+const data = {
+  version: pkg.version,
+  commit,
+  buildTime: new Date().toISOString(),
+};
+
+const outputDir = new URL('../dist/', import.meta.url);
+await mkdir(outputDir, { recursive: true });
+await writeFile(new URL('version.json', outputDir), JSON.stringify(data, null, 2));


### PR DESCRIPTION
## Summary
- write build version info to `web/dist/version.json`
- add postbuild step for version metadata and release tagging script

## Testing
- `npm test`
- `npm --prefix web run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npm --prefix web install` *(fails: unable to resolve dependency tree)*
- `npm --prefix web install --legacy-peer-deps` *(fails: 403 Forbidden for eslint-plugin-jsx-a11y)*

------
https://chatgpt.com/codex/tasks/task_e_68996eeaf1fc832ba559f1fe96f04fc5