### PR TITLE
chore(ci): parameterize release artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,17 +23,19 @@ jobs:
       - name: Build
         run: npm run build
       - name: Zip dist
-        run: zip -r dist.zip dist
+        run: zip -r "web-dist-${{ github.ref_name }}.zip" dist
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dist
-          path: web/dist.zip
+          name: web-dist-${{ github.ref_name }}
+          path: web/web-dist-${{ github.ref_name }}.zip
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
-          files: web/dist.zip
+          files: web/web-dist-${{ github.ref_name }}.zip
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body_path: CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- name release zip using the current ref
- upload artifact and release using the new name and softprops/action-gh-release v2

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68997118b504832bb4a7ec3381d6ff7c