### PR TITLE
Add timestamp to uptime alerts

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -15,16 +15,19 @@ jobs:
         id: health
         run: |
           status=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTHCHECK_URL")
+          timestamp=$(date -Iseconds)
           echo "status=$status" >> $GITHUB_OUTPUT
+          echo "timestamp=$timestamp" >> $GITHUB_OUTPUT
       - name: Create issue if down
         if: steps.health.outputs.status != '200'
         uses: actions/github-script@v7
         with:
           script: |
             const status = '${{ steps.health.outputs.status }}';
+            const timestamp = '${{ steps.health.outputs.timestamp }}';
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: 'Uptime alert',
-              body: `Health check failed with status ${status}.`
+              body: `Health check failed with status ${status} at ${timestamp}.`
             })


### PR DESCRIPTION
## Summary
- capture ISO timestamp in uptime workflow
- include timestamp in alert issue body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689971f802b0832baaf78236100fb808