### PR TITLE
chore: streamline release tagging scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "lollyspace-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js",
-    "release:tag": "git tag v1.0.0 && git push origin v1.0.0"
+    "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js"
   }
 }


### PR DESCRIPTION
## Summary
- remove hard-coded `release:tag` script from root `package.json`
- ensure web app uses dynamic release tagging command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689972d5c66c832bbafb99a0f2fe78c0