### PR TITLE
feat: add promotion metadata and items

### DIFF
--- a/supabase/migrations/20250901090000_promotions_updates.rollback.sql
+++ b/supabase/migrations/20250901090000_promotions_updates.rollback.sql
@@ -1,0 +1,11 @@
+-- Rollback promotion metadata and promotion_items table
+
+-- Remove added columns
+alter table public.promotions
+  drop column if exists name,
+  drop column if exists priority,
+  drop column if exists combinable,
+  drop column if exists scope_json;
+
+-- Drop promotion_items table
+DROP TABLE IF EXISTS public.promotion_items;

--- a/supabase/migrations/20250901090000_promotions_updates.sql
+++ b/supabase/migrations/20250901090000_promotions_updates.sql
@@ -1,0 +1,21 @@
+-- Add promotion metadata and promotion_items table
+
+-- Add columns to promotions table
+alter table public.promotions
+  add column if not exists name text not null default '',
+  add column if not exists priority integer not null default 0,
+  add column if not exists combinable boolean not null default true,
+  add column if not exists scope_json jsonb not null default '{}'::jsonb;
+
+-- Create promotion_items table
+create table if not exists public.promotion_items (
+  id bigserial primary key,
+  promotion_id bigint references public.promotions on delete cascade,
+  product_id bigint references public.products on delete cascade,
+  variant_id bigint references public.product_variants on delete cascade,
+  params_json jsonb not null default '{}'::jsonb
+);
+
+create index if not exists promotion_items_promotion_id_idx on public.promotion_items(promotion_id);
+create index if not exists promotion_items_product_id_idx on public.promotion_items(product_id);
+create index if not exists promotion_items_variant_id_idx on public.promotion_items(variant_id);


### PR DESCRIPTION
## Summary
- extend promotions with name, priority, combinable, and scope_json
- create promotion_items table linking promotions to products/variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689979451908832b9807e05d26d61058