### PR TITLE
feat: add promotion engine with bundle discounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "lollyspace-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js"
+    "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js && node --test tests/unit/promo_engine.test.ts"
   }
 }

--- a/src/lib/promo/engine.ts
+++ b/src/lib/promo/engine.ts
@@ -1,0 +1,68 @@
+function promoValid(promo, qty, now) {
+  if (promo.start && now < new Date(promo.start)) return false;
+  if (promo.end && now > new Date(promo.end)) return false;
+  if (promo.minQty && qty < promo.minQty) return false;
+  if (promo.maxQty && qty > promo.maxQty) return false;
+  return true;
+}
+
+function promoEngine(cart, promotions, now = new Date()) {
+  const cartAfter = cart.map((i) => ({ ...i, discount: 0, finalPrice: i.price * i.qty }));
+  const appliedMap = new Map();
+  let totalDiscount = 0;
+
+  const packPromos = promotions.filter((p) => p.type === 'PACK3');
+
+  for (const item of cartAfter) {
+    let best = { promo: null, discount: 0 };
+    for (const promo of promotions) {
+      if (promo.type === 'PACK3') continue;
+      if (promo.productId && promo.productId !== item.id) continue;
+      if (!promoValid(promo, item.qty, now)) continue;
+      let discount = 0;
+      if (promo.type === 'PERCENT') {
+        discount = item.price * item.qty * (promo.percent || 0) / 100;
+      } else if (promo.type === 'FIXED') {
+        discount = (promo.amount || 0) * item.qty;
+        const max = item.price * item.qty;
+        if (discount > max) discount = max;
+      } else if (promo.type === 'BxGy') {
+        const buy = promo.buy_qty || 0;
+        const get = promo.get_qty || 0;
+        if (buy > 0 && get > 0) {
+          const group = buy + get;
+          const deals = Math.floor(item.qty / group);
+          discount = deals * get * item.price;
+        }
+      }
+      if (discount > best.discount) best = { promo, discount };
+    }
+
+    for (const promo of packPromos) {
+      if (!promo.productIds || !promo.productIds.includes(item.id)) continue;
+      const items = promo.productIds.map((id) => cartAfter.find((ci) => ci.id === id));
+      if (items.some((ci) => !ci)) continue;
+      if (!promoValid(promo, item.qty, now)) continue;
+      const packCount = Math.min(...items.map((ci) => ci.qty));
+      if (packCount <= 0) continue;
+      const sumPrice = items.reduce((s, ci) => s + ci.price, 0);
+      const discountPerPack = sumPrice - (promo.pack_price || 0);
+      const perItem = discountPerPack / items.length;
+      const discount = perItem * packCount;
+      if (discount > best.discount) best = { promo, discount };
+    }
+
+    if (best.promo) {
+      item.discount = best.discount;
+      item.finalPrice = item.price * item.qty - best.discount;
+      totalDiscount += best.discount;
+      const rec = appliedMap.get(best.promo.id) || { id: best.promo.id, type: best.promo.type, discount: 0 };
+      rec.discount += best.discount;
+      appliedMap.set(best.promo.id, rec);
+    }
+  }
+
+  return { applied: Array.from(appliedMap.values()), totalDiscount, cartAfter };
+}
+
+module.exports = { promoEngine };

--- a/tests/unit/promo_engine.test.ts
+++ b/tests/unit/promo_engine.test.ts
@@ -1,0 +1,89 @@
+const test = require('node:test');
+const assert = require('assert');
+const { promoEngine } = require('../../src/lib/promo/engine.ts');
+
+const now = new Date('2024-01-01');
+
+const cases = [
+  {
+    name: 'overlapping promotions choose largest discount',
+    cart: [{ id: 'A', qty: 3, price: 100 }],
+    promos: [
+      { id: 'P1', type: 'PERCENT', productId: 'A', percent: 10 },
+      { id: 'P2', type: 'FIXED', productId: 'A', amount: 200 },
+      { id: 'P3', type: 'BxGy', productId: 'A', buy_qty: 2, get_qty: 1, combinable: false },
+    ],
+    expected: { totalDiscount: 300, applied: ['P2'] },
+  },
+  {
+    name: 'expired promotion ignored by date limits',
+    cart: [{ id: 'A', qty: 1, price: 100 }],
+    promos: [
+      { id: 'P1', type: 'PERCENT', productId: 'A', percent: 50, start: '2030-01-01', end: '2030-12-31' },
+    ],
+    now: new Date('2029-12-31'),
+    expected: { totalDiscount: 0, applied: [] },
+  },
+  {
+    name: 'quantity bounds prevent promotion',
+    cart: [
+      { id: 'A', qty: 1, price: 100 },
+      { id: 'B', qty: 5, price: 10 },
+    ],
+    promos: [
+      { id: 'P1', type: 'PERCENT', productId: 'A', percent: 50, minQty: 2 },
+      { id: 'P2', type: 'FIXED', productId: 'B', amount: 5, maxQty: 3 },
+    ],
+    expected: { totalDiscount: 0, applied: [] },
+  },
+  {
+    name: 'BxGy applies correct free units',
+    cart: [{ id: 'A', qty: 5, price: 10 }],
+    promos: [
+      { id: 'P1', type: 'BxGy', productId: 'A', buy_qty: 2, get_qty: 1 },
+    ],
+    expected: { totalDiscount: 10, applied: ['P1'] },
+  },
+  {
+    name: 'BxGy not applied when quantity insufficient',
+    cart: [{ id: 'A', qty: 2, price: 10 }],
+    promos: [
+      { id: 'P1', type: 'BxGy', productId: 'A', buy_qty: 2, get_qty: 1 },
+    ],
+    expected: { totalDiscount: 0, applied: [] },
+  },
+  {
+    name: 'PACK3 handles mixed prices',
+    cart: [
+      { id: 'A', qty: 1, price: 10 },
+      { id: 'B', qty: 1, price: 20 },
+      { id: 'C', qty: 1, price: 30 },
+    ],
+    promos: [
+      { id: 'P1', type: 'PACK3', productIds: ['A', 'B', 'C'], pack_price: 50 },
+    ],
+    expected: { totalDiscount: 10, applied: ['P1'] },
+  },
+  {
+    name: 'PACK3 ignored when a product missing',
+    cart: [
+      { id: 'A', qty: 1, price: 10 },
+      { id: 'B', qty: 1, price: 20 },
+    ],
+    promos: [
+      { id: 'P1', type: 'PACK3', productIds: ['A', 'B', 'C'], pack_price: 50 },
+    ],
+    expected: { totalDiscount: 0, applied: [] },
+  },
+];
+
+for (const c of cases) {
+  test(c.name, () => {
+    const res = promoEngine(c.cart, c.promos, c.now || now);
+    assert.strictEqual(res.totalDiscount, c.expected.totalDiscount);
+    assert.deepStrictEqual(res.applied.map((a) => a.id).sort(), c.expected.applied.sort());
+    // Ensure cartAfter discounts sum matches total
+    const sum = res.cartAfter.reduce((s, i) => s + i.discount, 0);
+    assert.strictEqual(sum, c.expected.totalDiscount);
+  });
+}


### PR DESCRIPTION
## Summary
- add promotion engine supporting percent, fixed, buy-x-get-y and pack-of-three promos
- report applied promotions, total discount and updated cart
- cover overlapping, date, quantity and pricing scenarios with unit tests

## Testing
- `npm test`
- `node --test --experimental-test-coverage tests/unit/promo_engine.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68997a5d3c54832b916ba797392a589e