### PR TITLE
test: add promotion mapping coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,8 +183,7 @@ jobs:
 
       - name: Run E2E tests
         if: steps.npm-registry.outputs.ok == 'true'
-        run: |
-          npx --yes @playwright/test@1.54.2 test --reporter=line
+        run: npm run test:e2e
         working-directory: web
 
       - name: Skip E2E (npm registry blocked)

--- a/web/tests/e2e/promotions.spec.ts
+++ b/web/tests/e2e/promotions.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+// Opportunistic E2E spec verifying PACK3 and BxGy promotion scenarios
+// by mocking the promotions API and promotion application endpoint.
+test('PACK3 and BxGy promotions', async ({ page }) => {
+  await page.route('**/api/admin/promotions', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'pack3', name: 'Pack 3', type: 'pack' },
+        { id: 'bxgy', name: 'Buy X Get Y', type: 'two_plus_one' },
+      ]),
+    });
+  });
+
+  await page.route('**/functions/v1/apply_promotions', async (route) => {
+    const req = await route.request().postDataJSON();
+    const items = req.items.map((i: any) => {
+      let discount_tnd = 0;
+      if (i.product_variant_id === 1 && i.qty >= 3) {
+        discount_tnd = Number((i.unit_price_tnd / 3).toFixed(3));
+      } else if (i.product_variant_id === 2 && i.qty >= 2) {
+        discount_tnd = Number((i.unit_price_tnd / 2).toFixed(3));
+      }
+      return { ...i, discount_tnd };
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items }),
+    });
+  });
+
+  await page.goto('data:text/html,<html></html>');
+
+  const promos = await page.evaluate(async () => {
+    const res = await fetch('https://example.com/api/admin/promotions');
+    return res.json();
+  });
+  expect(promos).toHaveLength(2);
+
+  const packRes = await page.evaluate(async () => {
+    const res = await fetch('https://example.com/functions/v1/apply_promotions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [{ product_variant_id: 1, qty: 3, unit_price_tnd: 1 }],
+      }),
+    });
+    return res.json();
+  });
+  expect(packRes.items[0].discount_tnd).toBeCloseTo(0.333, 3);
+
+  const bxgyRes = await page.evaluate(async () => {
+    const res = await fetch('https://example.com/functions/v1/apply_promotions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        items: [{ product_variant_id: 2, qty: 2, unit_price_tnd: 1 }],
+      }),
+    });
+    return res.json();
+  });
+  expect(bxgyRes.items[0].discount_tnd).toBeCloseTo(0.5, 3);
+});

--- a/web/tests/unit/promo_mapping.test.ts
+++ b/web/tests/unit/promo_mapping.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import AdvisorCart from '@/pages/AdvisorCart';
+import { useCartStore } from '@/stores/cart';
+
+// Reset cart store before each test
+beforeEach(() => {
+  useCartStore.setState({ items: [] });
+});
+
+describe('cart promo mapping', () => {
+  it('rounds discounted prices and displays savings', () => {
+    useCartStore.setState({
+      items: [
+        {
+          product_variant_id: 1,
+          name: 'Test',
+          qty: 2,
+          unit_price_tnd: 1,
+          discount_tnd: 0.333333,
+        },
+      ],
+    });
+
+    const html = renderToString(<AdvisorCart />);
+    expect(html).toContain('0.667 TND');
+    expect(html).toContain('-0.667 TND');
+  });
+});


### PR DESCRIPTION
## Summary
- add cart promo mapping unit test to verify price rounding and savings
- introduce promotion E2E spec exercising PACK3 and BxGy scenarios with mocked endpoints
- run E2E via npm script in CI workflow

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*
- `npm run test:unit` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*

------
https://chatgpt.com/codex/tasks/task_e_689980dfd4bc832b8a5065a75b00762a