### PR TITLE
fix: use ESLint 8 to satisfy TypeScript-ESLint peer deps

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
-    "eslint": "^9.32.0",
+    "eslint": "^8.57.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",


### PR DESCRIPTION
## Summary
- pin ESLint to v8 to satisfy @typescript-eslint parser/plugin peer dependency requirements

## Testing
- `npm test`
- `npm test` (web) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899a0a8ba34832bb4b6760e440f67b9