### PR TITLE
chore: fix npm registry and align eslint deps

### DIFF
--- a/.github/workflows/regen-lockfile.yml
+++ b/.github/workflows/regen-lockfile.yml
@@ -1,0 +1,45 @@
+name: Regen lockfile and push
+on:
+  push:
+    branches: [ codex/update-package.json-for-node-20-and-dependencies ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Use Node 20 and npmjs registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Ensure npm uses npmjs
+        run: |
+          echo "registry=https://registry.npmjs.org/" > .npmrc
+          cat .npmrc
+      - name: Clean node_modules and lockfile
+        run: rm -rf node_modules package-lock.json
+      - name: Install to regenerate lockfile
+        run: npm install
+      - name: Verify CI and build
+        run: |
+          npm ci
+          npm run build --if-present
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .npmrc package.json package-lock.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: fix npm registry, align eslint@8 with @typescript-eslint@7, regenerate lockfile"
+            git push
+          else
+            echo "No changes to commit."
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry=https://registry.npmjs.org/
+always-auth=false
+# IMPORTANT : ne mets AUCUNE ligne du type "@eslint:registry=..."
+# Supprime tout .npmrc dans des sous-dossiers qui redirige des scopes.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,19 @@
 {
   "name": "lollyspace-tests",
   "version": "1.0.0",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "test": "node tests/apply_promotions.test.js && node tests/seed_commissions.test.js && node tests/commissions_export.test.js && node tests/checkout.test.js && node tests/search_products.test.js && node --test tests/unit/promo_engine.test.ts"
+  },
+  "devDependencies": {
+    "eslint": "8.57.1",
+    "@eslint/js": "8.57.1",
+    "@typescript-eslint/parser": "7.18.0",
+    "@typescript-eslint/eslint-plugin": "7.18.0",
+    "eslint-plugin-react": "7.37.5",
+    "eslint-plugin-react-hooks": "4.6.2",
+    "eslint-plugin-jsx-a11y": "6.10.2"
   }
 }


### PR DESCRIPTION
## Summary
- configure npm to use the npmjs registry
- align eslint 8 with @typescript-eslint 7 and require Node 20
- add workflow to regenerate package-lock.json on pushes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899a7274ed8832b880a02fdab2c33fd